### PR TITLE
Helpful errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,20 +28,11 @@ dependencies = [
 
 [[package]]
 name = "allo-isolate"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13e2dba4602fed6c46f7d5cae67fe0fb9a6af1ce01848228f7533a8450c73be"
+checksum = "31644a919a9e4b0188e4569e55bbf5a78b5588ea645acffc15c29240407261bc"
 dependencies = [
  "atomic",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -55,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.45"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
+checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
 name = "atomic"
@@ -145,11 +136,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term",
  "atty",
  "bitflags",
  "strsim",
@@ -173,12 +164,6 @@ name = "diff"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
-
-[[package]]
-name = "dtoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "example"
@@ -445,9 +430,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.107"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "linked-hash-map"
@@ -586,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "output_vt100"
@@ -642,7 +627,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0cfe1b2403f172ba0f234e500906ee0a3e493fb81092dac23ebefe129301cc"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "ctor",
  "diff",
  "output_vt100",
@@ -686,9 +671,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
 dependencies = [
  "unicode-xid",
 ]
@@ -748,18 +733,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde-generate"
-version = "0.20.4"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d21a0eac880b198ad66cfcf4170f1b18e036756f12ad393a1d0c8cfaa2cedf"
+checksum = "b5cf21ac6679c60495e22ed041e2c913740f0332597c6a64bbcba04dbcb39249"
 dependencies = [
  "bcs",
  "bincode",
@@ -796,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -818,12 +803,12 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
 dependencies = [
- "dtoa",
  "indexmap",
+ "ryu",
  "serde",
  "yaml-rust",
 ]
@@ -909,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -980,11 +965,10 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
- "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -1000,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "membrane"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "allo-isolate",
  "bincode",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "membrane_macro"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "membrane_types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +498,7 @@ dependencies = [
  "serde-generate",
  "serde-reflection",
  "serial_test",
+ "trybuild",
 ]
 
 [[package]]
@@ -728,6 +735,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +803,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -907,6 +931,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1021,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d664de8ea7e531ad4c0f5a834f20b8cb2b8e6dfe88d05796ee7887518ed67b9"
+dependencies = [
+ "glob",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "termcolor",
+ "toml",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1088,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "membrane"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "allo-isolate",
  "bincode",

--- a/membrane/Cargo.toml
+++ b/membrane/Cargo.toml
@@ -35,3 +35,4 @@ serde-reflection = "0.3.5"
 example = {path = "../example"}
 pretty_assertions = "1.0.0"
 serial_test = "0.5.1"
+trybuild = "1.0"

--- a/membrane/Cargo.toml
+++ b/membrane/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "membrane"
 readme = "../README.md"
 repository = "https://github.com/jerel/membrane"
-version = "0.3.3"
+version = "0.3.4"
 
 [lib]
 crate-type = ["lib"]

--- a/membrane/tests/compiler_tests.rs
+++ b/membrane/tests/compiler_tests.rs
@@ -1,0 +1,5 @@
+#[test]
+fn ui() {
+  let t = trybuild::TestCases::new();
+  t.compile_fail("tests/ui/*.rs");
+}

--- a/membrane/tests/ui/single.rs
+++ b/membrane/tests/ui/single.rs
@@ -1,0 +1,36 @@
+use futures::Future;
+use membrane::async_dart;
+
+struct Runtime {}
+impl Runtime {
+  pub fn spawn<T>(&self, future: T)
+  where
+    T: Future + Send + 'static,
+    T::Output: Send + 'static,
+  {
+  }
+}
+
+static RUNTIME: Runtime = Runtime {};
+
+#[async_dart(namespace = "a")]
+pub async fn no_result() -> i32 {}
+
+#[async_dart(namespace = "a")]
+pub async fn no_result_bare_vec() -> Vec<i32> {}
+
+#[async_dart(namespace = "a")]
+pub async fn bare_vec() -> Result<Vec<i32>, String> {}
+
+#[async_dart(namespace = "a")]
+pub async fn bare_tuple() -> Result<(i32, i32), String> {}
+
+#[async_dart(namespace = "a")]
+pub async fn option() -> Result<Option<i32>, String> {}
+
+#[async_dart(namespace = "a")]
+pub async fn one_success() -> Result<i32, String> {
+  Ok(10)
+}
+
+fn main() {}

--- a/membrane/tests/ui/single.stderr
+++ b/membrane/tests/ui/single.stderr
@@ -1,0 +1,29 @@
+error: expected enum `Result`
+  --> tests/ui/single.rs:17:29
+   |
+17 | pub async fn no_result() -> i32 {}
+   |                             ^^^
+
+error: expected enum `Result`
+  --> tests/ui/single.rs:20:38
+   |
+20 | pub async fn no_result_bare_vec() -> Vec<i32> {}
+   |                                      ^^^
+
+error: A vector may not be returned from an `async_dart` function. If a vector is needed return a struct containing the vector.
+  --> tests/ui/single.rs:23:35
+   |
+23 | pub async fn bare_vec() -> Result<Vec<i32>, String> {}
+   |                                   ^^^
+
+error: A tuple may not be returned from an `async_dart` function. If a tuple is needed return a struct containing the tuple.
+  --> tests/ui/single.rs:26:37
+   |
+26 | pub async fn bare_tuple() -> Result<(i32, i32), String> {}
+   |                                     ^
+
+error: expected a struct or scalar type
+  --> tests/ui/single.rs:29:33
+   |
+29 | pub async fn option() -> Result<Option<i32>, String> {}
+   |                                 ^^^^^^

--- a/membrane/tests/ui/stream.rs
+++ b/membrane/tests/ui/stream.rs
@@ -1,0 +1,30 @@
+use futures::{Future, Stream};
+use membrane::async_dart;
+
+struct Runtime {}
+impl Runtime {
+  pub fn spawn<T>(&self, future: T)
+  where
+    T: Future + Send + 'static,
+    T::Output: Send + 'static,
+  {
+  }
+}
+
+static RUNTIME: Runtime = Runtime {};
+
+#[async_dart(namespace = "a")]
+pub fn one_failure() -> impl Stream<i32, String> {}
+
+#[async_dart(namespace = "a")]
+pub fn two_failure() -> impl Stream<Item = i32, String> {}
+
+#[async_dart(namespace = "a")]
+pub fn three_failure() -> impl Stream<Item = Result<Option<i32>, String>> {}
+
+#[async_dart(namespace = "a")]
+pub fn one_success() -> impl Stream<Item = Result<i32, String>> {
+  futures::stream::iter(vec![])
+}
+
+fn main() {}

--- a/membrane/tests/ui/stream.stderr
+++ b/membrane/tests/ui/stream.stderr
@@ -1,0 +1,17 @@
+error: expected `impl Stream<Item = Result>`
+  --> tests/ui/stream.rs:17:30
+   |
+17 | pub fn one_failure() -> impl Stream<i32, String> {}
+   |                              ^^^^^^
+
+error: expected enum `Result`
+  --> tests/ui/stream.rs:20:44
+   |
+20 | pub fn two_failure() -> impl Stream<Item = i32, String> {}
+   |                                            ^^^
+
+error: expected a struct or scalar type
+  --> tests/ui/stream.rs:23:53
+   |
+23 | pub fn three_failure() -> impl Stream<Item = Result<Option<i32>, String>> {}
+   |                                                     ^^^^^^

--- a/membrane_macro/Cargo.toml
+++ b/membrane_macro/Cargo.toml
@@ -4,7 +4,7 @@ description = "A companion crate for `membrane`"
 edition = "2018"
 license = "Apache-2.0"
 name = "membrane_macro"
-version = "0.3.0"
+version = "0.3.1"
 
 [lib]
 proc-macro = true

--- a/membrane_macro/src/parsers.rs
+++ b/membrane_macro/src/parsers.rs
@@ -1,0 +1,79 @@
+use membrane_types::{syn, OutputStyle};
+use syn::parse::{ParseStream, Result};
+use syn::{Error, Expr, Ident, Path, Token};
+
+pub fn parse_stream_return_type(input: ParseStream) -> Result<(OutputStyle, Expr, Path)> {
+  input.parse::<Token![impl]>()?;
+  let span = input.span();
+  let stream_ident = input.parse::<Ident>()?;
+  input.parse::<Token![<]>()?;
+  let item_ident = input.parse::<Ident>()?;
+
+  if stream_ident != "Stream" || item_ident != "Item" {
+    return Err(Error::new(span, "expected `impl Stream<Item = Result>`"));
+  }
+
+  input.parse::<Token![=]>()?;
+  let (t, e) = parse_type(input)?;
+  input.parse::<Token![>]>()?;
+
+  Ok((OutputStyle::StreamSerialized, t, e))
+}
+
+pub fn parse_return_type(input: ParseStream) -> Result<(OutputStyle, Expr, Path)> {
+  let (t, e) = parse_type(input)?;
+  Ok((OutputStyle::Serialized, t, e))
+}
+
+fn parse_type(input: ParseStream) -> Result<(Expr, Path)> {
+  let outer_span = input.span();
+  match input.parse::<Ident>()? {
+    ident if ident == "Result" => (),
+    _ => {
+      return Err(Error::new(outer_span, "expected enum `Result`"));
+    }
+  }
+
+  input.parse::<Token![<]>()?;
+
+  let type_span = input.span();
+  // handle the empty unit () type
+  let t = if input.peek(syn::token::Paren) {
+    let tuple = input.parse::<syn::ExprTuple>()?;
+    if !tuple.elems.is_empty() {
+      return Err(Error::new(
+        type_span,
+        "A tuple may not be returned from an `async_dart` function. If a tuple is needed return a struct containing the tuple.",
+      ));
+    }
+    Expr::Tuple(tuple)
+  } else {
+    Expr::Path(input.parse::<syn::ExprPath>()?)
+  };
+
+  match input.parse::<Token![,]>() {
+    Ok(_) => (),
+    Err(_err) => {
+      let type_name = match t {
+        Expr::Path(syn::ExprPath { path, .. }) if !path.segments.is_empty() => {
+          path.segments.first().unwrap().ident.to_string()
+        }
+        _ => String::new(),
+      };
+
+      match type_name.as_str() {
+        "Vec" => {
+          return Err(Error::new(type_span, "A vector may not be returned from an `async_dart` function. If a vector is needed return a struct containing the vector."));
+        }
+        _ => {
+          return Err(Error::new(type_span, "expected a struct or scalar type"));
+        }
+      }
+    }
+  }
+
+  let e = input.parse::<Path>()?;
+  input.parse::<Token![>]>()?;
+
+  Ok((t, e))
+}


### PR DESCRIPTION
This PR updates the `#[async_dart]` compiler errors from generic syntax errors to descriptive errors with spans that indicate the unsupported data types:

![Screenshot from 2021-12-17 10-43-23](https://user-images.githubusercontent.com/322706/146604739-1a2514b0-f11e-45d7-9143-c18dd7025362.png)

Also adds `trybuild` to test compiler errors to ensure future stability for users.