### PR TITLE
Fix/example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,49 @@
     * `apt-get install libclang-dev`
   * MacOS
     * `brew install llvm`
+  * MacOS M1
+    * there's a couple more steps, see below
 
 On Linux ffigen looks for libclang at `/usr/lib/llvm-11/lib/libclang.so` so you may need to symlink to the version specific library: `ln -s /usr/lib/llvm-11/lib/libclang.so.1 /usr/lib/llvm-11/lib/libclang.so`.
+
+On MacOS M1, ffigen still uses llvm for x86 architecture so far, while M1 is arm64: you might get an error mentioning *incompatible architecture (have 'arm64', need 'x86_64')*.
+
+<details>
+<summary>click & follow steps</summary>
+
+Essentially, you will need to install x86_64 variants of tools.
+Grab a coffee, this might take a while :coffee:
+
+- Rosetta2 (optional, only if asked)
+- Rust toolchain
+  ```sh
+  rustup target add x86_64-apple-darwin
+  ```
+- brew
+  ```sh
+  arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+  ```
+- llvm
+  ```sh
+  arch -x86_64 /usr/local/bin/brew install llvm
+  ```
+  ⚠️ if asked to install additional packages,
+  just follow recommendations in the console, e.g. :
+  ```sh
+  arch -x86_64 /usr/local/bin/brew install python@3.10
+  ```
+- ffi
+  ```sh
+  arch -x86_64 sudo gem install ffi
+  ```
+- finally run!
+  ```sh
+  # MEMBRANE_LLVM_PATHS must be set to folder's path
+  # where llvm for x86_64 is installed
+  export MEMBRANE_LLVM_PATHS=/usr/local/opt/llvm && cargo run --target=x86_64-apple-darwin
+  ```
+
+</details>
 
 ## Usage
 

--- a/dart_example/test/enum_test.dart
+++ b/dart_example/test/enum_test.dart
@@ -1,6 +1,5 @@
 import 'package:test/test.dart';
 import 'package:dart_example/accounts.dart';
-import 'package:dart_example/locations.dart';
 
 void main() {
   test('can handle a class enum', () async {

--- a/dart_example/test/enum_test.dart
+++ b/dart_example/test/enum_test.dart
@@ -5,9 +5,9 @@ import 'package:dart_example/locations.dart';
 void main() {
   test('can handle a class enum', () async {
     final accounts = AccountsApi();
-    expect((await accounts.enumReturn(status: StatusActiveItem())),
-        equals(StatusActiveItem()));
-    expect((await accounts.enumReturn(status: StatusPendingItem())),
-        isNot(equals(StatusActiveItem())));
+    expect((await accounts.enumReturn(status: Status.active)),
+        equals(Status.active));
+    expect((await accounts.enumReturn(status: Status.active)),
+        isNot(equals(Status.pending)));
   });
 }

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -11,7 +11,7 @@ name = "generator"
 path = "src/generator.rs"
 
 [lib]
-crate-type = ["lib", "cdylib", "staticlib"]
+crate-type = ["lib", "cdylib", "staticlib", "dylib"]
 
 [features]
 codegen = ["membrane/generate"]

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -418,6 +418,7 @@ impl<'a> Membrane {
 
 dev_dependencies:
   ffigen: ^4.1.0
+  test: ^1.20.1
 "#;
       std::fs::write(path, pubspec + extra_deps).expect("pubspec could not be written");
     }


### PR DESCRIPTION
Hello again!
I could correctly build the plugin so far,
then I tried to run the tests in the generated `dart_example` folder but there was a few minor obstacles:

- `test` dependency was missing in `dart_example/pubspec.yml`
- fixed `dart_example/test/enum_test.dart`
- for a reason that I ignore I had to build with crate type `dylib`
- manually copy built Rust library to `../dart_example/libexample.dylib`
  
   probably because on M1 I'm required to run:
  ```sh
  export MEMBRANE_LLVM_PATHS=/usr/local/opt/llvm && cargo run --target=x86_64-apple-darwin
  ```
  which builds to `example/target/x86_64-apple-darwin/debug/libexample.dylib` instead.
  
   Library is called `libexample.dylib`, as per [generator lib arg](https://github.com/jerel/membrane/blob/4ddfb1c7f6afcf5345ff624f1afb54d5f13ccaa9/example/src/generator.rs#L9)
  while some binaries are called `generator` / `generator.d` after [Cargo bin name](https://github.com/jerel/membrane/blob/4ddfb1c7f6afcf5345ff624f1afb54d5f13ccaa9/example/Cargo.toml#L10)
  honestly I'm not sure if it matters, but in case.
  
Now, it runs smooth :)