### PR TITLE
Add timeout functionality for async receive ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "membrane"
-version = "0.5.1"
+version = "0.6.1"
 dependencies = [
  "allo-isolate",
  "bincode",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "membrane_macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "membrane_types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +190,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 name = "example"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "futures",
  "membrane",
  "once_cell",

--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -194,4 +194,40 @@ void main() {
 
     expect(logs, equals([]));
   });
+
+  test(
+      'test that a slow function will throw a timeout at its #[async_dart(timeout=100)] configured duration',
+      () async {
+    final accounts = AccountsApi();
+    try {
+      await accounts.slowFunction(sleepFor: 150);
+    } on TimeoutException catch (err) {
+      expect(err.duration?.inMilliseconds, 100);
+      expect(err.message, "Future not completed");
+    }
+  });
+
+  test(
+      'test that a slow function will throw a timeout at its globally configured (200) timeout duration',
+      () async {
+    final accounts = AccountsApi();
+    try {
+      await accounts.slowFunctionTwo(sleepFor: 250);
+    } on TimeoutException catch (err) {
+      expect(err.duration?.inMilliseconds, 200);
+      expect(err.message, "Future not completed");
+    }
+  });
+
+  test(
+      'test that a stream with a timeout will disconnect if the time between events exceeds set timeout',
+      () async {
+    final accounts = AccountsApi();
+    try {
+      await accounts.slowStream(sleepFor: 100).take(2).toList();
+    } on TimeoutException catch (err) {
+      expect(err.duration?.inMilliseconds, 50);
+      expect(err.message, "No stream event");
+    }
+  });
 }

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -51,6 +51,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +190,7 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 name = "example"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "futures",
  "membrane",
  "once_cell",
@@ -460,7 +482,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "membrane"
-version = "0.4.0"
+version = "0.6.1"
 dependencies = [
  "allo-isolate",
  "bincode",
@@ -478,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "membrane_macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "membrane_types",
 ]

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -18,6 +18,7 @@ codegen = ["membrane/generate"]
 skip-codegen = ["membrane/skip-generate"]
 
 [dependencies]
+async-stream = "0.3"
 futures = "0.3"
 membrane = {path = "../membrane"}
 once_cell = "1.8"

--- a/example/src/application.rs
+++ b/example/src/application.rs
@@ -170,6 +170,33 @@ pub async fn enum_return(status: data::Status) -> Result<data::Status, String> {
   Ok(status)
 }
 
+#[async_dart(namespace = "accounts", timeout = 100)]
+pub async fn slow_function(sleep_for: i64) -> Result<(), String> {
+  use tokio::time::{sleep, Duration};
+  sleep(Duration::from_millis(sleep_for as u64)).await;
+  Ok(())
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn slow_function_two(sleep_for: i64) -> Result<(), String> {
+  use tokio::time::{sleep, Duration};
+  sleep(Duration::from_millis(sleep_for as u64)).await;
+  Ok(())
+}
+
+#[async_dart(namespace = "accounts", timeout = 50)]
+pub fn slow_stream(sleep_for: i64) -> impl Stream<Item = Result<i32, String>> {
+  use async_stream::stream;
+  use tokio::time::{sleep, Duration};
+
+  stream! {
+    for i in 0..3 {
+      sleep(Duration::from_millis(sleep_for as u64)).await;
+      yield Ok(i);
+    }
+  }
+}
+
 #[async_dart(namespace = "locations")]
 pub async fn get_location(id: i64) -> Result<data::Location, String> {
   let _id = id;

--- a/example/src/generator.rs
+++ b/example/src/generator.rs
@@ -4,6 +4,7 @@ fn main() {
 
   let mut project = membrane::Membrane::new();
   project
+    .timeout(200)
     .package_destination_dir("../dart_example")
     .package_name("dart_example")
     .using_lib("libexample")

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -10,6 +10,7 @@ pub(crate) static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
   Builder::new_multi_thread()
     .worker_threads(2)
     .thread_name("example")
+    .enable_time()
     .build()
     .unwrap()
 });

--- a/membrane/Cargo.toml
+++ b/membrane/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "membrane"
 readme = "../README.md"
 repository = "https://github.com/jerel/membrane"
-version = "0.5.1"
+version = "0.6.0"
 
 [lib]
 crate-type = ["lib"]

--- a/membrane/Cargo.toml
+++ b/membrane/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "membrane"
 readme = "../README.md"
 repository = "https://github.com/jerel/membrane"
-version = "0.6.0"
+version = "0.6.1"
 
 [lib]
 crate-type = ["lib"]
@@ -24,7 +24,7 @@ ffi_helpers = "0.2"
 futures = "0.3"
 heck = "0.3"
 inventory = "0.1"
-membrane_macro = {version = "^0.4", path = "../membrane_macro"}
+membrane_macro = {version = "^0.5", path = "../membrane_macro"}
 membrane_types = {version = "^0.3", path = "../membrane_types"}
 regex = "1.5"
 serde = {version = "1.0", features = ["derive"]}

--- a/membrane/tests/integration_tests.rs
+++ b/membrane/tests/integration_tests.rs
@@ -16,6 +16,7 @@ mod test {
     let _ = example::load();
 
     Membrane::new()
+      .timeout(200)
       .package_destination_dir(path)
       .using_lib("libexample")
       .create_pub_package()

--- a/membrane_macro/Cargo.toml
+++ b/membrane_macro/Cargo.toml
@@ -4,7 +4,7 @@ description = "A companion crate for `membrane`"
 edition = "2018"
 license = "Apache-2.0"
 name = "membrane_macro"
-version = "0.4.0"
+version = "0.5.0"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
While previous releases contained a call to `timeout(Duration(milliseconds: 1000))` on the codegenerated ReceivePort the timeout did not actually throw an exception if it was reached due to the behavior of `ReceivePort()..timeout()`. This PR fixes that bug and makes timeouts configurable at the project level and also at the function level. Timeouts can now be customized (even on streams) by passing the `timeout` option to `async_dart`. Example:
```
#[async_dart(namespace = "foo", timeout = 200)]
pub async fn example() -> Result<String, String> {}
```