### PR TITLE
Add support for top level vectors as arguments and return values

### DIFF
--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -173,7 +173,7 @@ void main() {
   test('can pass a vec of structs', () async {
     final accounts = AccountsApi();
     expect(
-        (await accounts.vecArg(contacts: [
+        (await accounts.vecStruct(values: [
           Contact(id: 1, fullName: 'Alice Smith', status: Status.pending),
           Contact(id: 2, fullName: 'John Smith', status: Status.active)
         ])),
@@ -203,6 +203,43 @@ void main() {
   test('can handle a vec of floats', () async {
     final accounts = AccountsApi();
     expect((await accounts.vecFloat(values: [1.0, 2.1])), equals([1.0, 2.1]));
+  });
+
+  test('can pass a vec of optional structs', () async {
+    final accounts = AccountsApi();
+    expect(
+        (await accounts.vecOptionStruct(values: [
+          null,
+          Contact(id: 2, fullName: 'John Smith', status: Status.active)
+        ])),
+        equals([
+          null,
+          Contact(id: 2, fullName: 'John Smith', status: Status.active)
+        ]));
+  });
+
+  test('can handle a vec of optional strings', () async {
+    final accounts = AccountsApi();
+    expect((await accounts.vecOptionString(values: [null, "hello", "world"])),
+        equals([null, "hello", "world"]));
+  });
+
+  test('can handle a vec of optional booleans', () async {
+    final accounts = AccountsApi();
+    expect((await accounts.vecOptionBool(values: [false, null, true])),
+        equals([false, null, true]));
+  });
+
+  test('can handle a vec of optional integers', () async {
+    final accounts = AccountsApi();
+    expect((await accounts.vecOptionInt(values: [1, null, 2])),
+        equals([1, null, 2]));
+  });
+
+  test('can handle a vec of optional floats', () async {
+    final accounts = AccountsApi();
+    expect((await accounts.vecOptionFloat(values: [1.0, 2.1, null])),
+        equals([1.0, 2.1, null]));
   });
 
   test('can pass a tuple arg containing a vec of structs', () async {

--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -170,6 +170,19 @@ void main() {
     expect(returned.toString(), types.toString());
   });
 
+  test('can pass a vec of structs', () async {
+    final accounts = AccountsApi();
+    expect(
+        (await accounts.vecArg(contacts: [
+          Contact(id: 1, fullName: 'Alice Smith', status: Status.pending),
+          Contact(id: 2, fullName: 'John Smith', status: Status.active)
+        ])),
+        equals([
+          Contact(id: 1, fullName: 'Alice Smith', status: Status.pending),
+          Contact(id: 2, fullName: 'John Smith', status: Status.active)
+        ]));
+  });
+
   test('can pass a tuple arg containing a vec of structs', () async {
     final accounts = AccountsApi();
     expect(

--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -101,7 +101,12 @@ void main() {
 
   test('can call a function that returns a scalar value', () async {
     final accounts = AccountsApi();
+    expect(await accounts.scalarI8(val: 123), equals(123));
+    expect(await accounts.scalarU8(val: 123), equals(123));
+    expect(await accounts.scalarI16(val: 123), equals(123));
+    expect(await accounts.scalarU16(val: 123), equals(123));
     expect(await accounts.scalarI32(val: 123), equals(123));
+    expect(await accounts.scalarU32(val: 123), equals(123));
     expect(await accounts.scalarI64(val: 10), equals(10));
     expect((await accounts.scalarF32(val: 21.1)).toStringAsFixed(1),
         equals('21.1'));

--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -183,6 +183,28 @@ void main() {
         ]));
   });
 
+  test('can handle a vec of strings', () async {
+    final accounts = AccountsApi();
+    expect((await accounts.vecString(values: ["hello", "world"])),
+        equals(["hello", "world"]));
+  });
+
+  test('can handle a vec of booleans', () async {
+    final accounts = AccountsApi();
+    expect(
+        (await accounts.vecBool(values: [true, false])), equals([true, false]));
+  });
+
+  test('can handle a vec of integers', () async {
+    final accounts = AccountsApi();
+    expect((await accounts.vecInt(values: [1, 2])), equals([1, 2]));
+  });
+
+  test('can handle a vec of floats', () async {
+    final accounts = AccountsApi();
+    expect((await accounts.vecFloat(values: [1.0, 2.1])), equals([1.0, 2.1]));
+  });
+
   test('can pass a tuple arg containing a vec of structs', () async {
     final accounts = AccountsApi();
     expect(

--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -205,6 +205,32 @@ void main() {
     expect((await accounts.vecFloat(values: [1.0, 2.1])), equals([1.0, 2.1]));
   });
 
+  test('can handle a vec of vecs', () async {
+    final accounts = AccountsApi();
+    expect(
+        (await accounts.vecVec(values: [
+          [1, 2],
+          [3, 4]
+        ])),
+        equals([
+          [1, 2],
+          [3, 4]
+        ]));
+  });
+
+  test('can handle a vec of nullable vecs', () async {
+    final accounts = AccountsApi();
+    expect(
+        (await accounts.vecVecOption(values: [
+          [1, 2],
+          [null, 4]
+        ])),
+        equals([
+          [1, 2],
+          [null, 4]
+        ]));
+  });
+
   test('can pass a vec of optional structs', () async {
     final accounts = AccountsApi();
     expect(

--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -218,16 +218,28 @@ void main() {
         ]));
   });
 
-  test('can handle a vec of nullable vecs', () async {
+  test('can handle a vec of optional nullable vecs', () async {
     final accounts = AccountsApi();
     expect(
         (await accounts.vecVecOption(values: [
-          [1, 2],
-          [null, 4]
+          [
+            [1, null],
+            [3, 4]
+          ],
+          [
+            null,
+            [5, 6]
+          ]
         ])),
         equals([
-          [1, 2],
-          [null, 4]
+          [
+            [1, null],
+            [3, 4]
+          ],
+          [
+            null,
+            [5, 6]
+          ]
         ]));
   });
 

--- a/example/src/application/advanced.rs
+++ b/example/src/application/advanced.rs
@@ -253,6 +253,13 @@ pub async fn more_types(types: data::MoreTypes) -> Result<data::MoreTypes, Strin
 }
 
 #[async_dart(namespace = "accounts")]
+pub async fn vec_arg(contacts: Vec<data::Contact>) -> Result<Vec<data::Contact>, String> {
+  println!("\n[Rust] Received vec: {:?}", contacts);
+
+  Ok(contacts)
+}
+
+#[async_dart(namespace = "accounts")]
 pub async fn filter_arg(filter: data::Filter) -> Result<data::Contacts, String> {
   println!("\n[Rust] Received filter: {:?}", filter);
 

--- a/example/src/application/advanced.rs
+++ b/example/src/application/advanced.rs
@@ -288,6 +288,22 @@ pub async fn vec_float(values: Vec<f64>) -> Result<Vec<f64>, String> {
 }
 
 #[async_dart(namespace = "accounts")]
+pub async fn vec_vec(values: Vec<Vec<i64>>) -> Result<Vec<Vec<i64>>, String> {
+  println!("\n[Rust] Received nested vec: {:?}", values);
+
+  Ok(values)
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn vec_vec_option(
+  values: Vec<Vec<Option<i64>>>,
+) -> Result<Vec<Vec<Option<i64>>>, String> {
+  println!("\n[Rust] Received nested vec of options: {:?}", values);
+
+  Ok(values)
+}
+
+#[async_dart(namespace = "accounts")]
 pub async fn vec_option_struct(
   values: Vec<Option<data::Contact>>,
 ) -> Result<Vec<Option<data::Contact>>, String> {

--- a/example/src/application/advanced.rs
+++ b/example/src/application/advanced.rs
@@ -296,9 +296,12 @@ pub async fn vec_vec(values: Vec<Vec<i64>>) -> Result<Vec<Vec<i64>>, String> {
 
 #[async_dart(namespace = "accounts")]
 pub async fn vec_vec_option(
-  values: Vec<Vec<Option<i64>>>,
-) -> Result<Vec<Vec<Option<i64>>>, String> {
-  println!("\n[Rust] Received nested vec of options: {:?}", values);
+  values: Vec<Vec<Option<Vec<Option<i64>>>>>,
+) -> Result<Vec<Vec<Option<Vec<Option<i64>>>>>, String> {
+  println!(
+    "\n[Rust] Received nested vec of optional vecs: {:?}",
+    values
+  );
 
   Ok(values)
 }

--- a/example/src/application/advanced.rs
+++ b/example/src/application/advanced.rs
@@ -253,10 +253,10 @@ pub async fn more_types(types: data::MoreTypes) -> Result<data::MoreTypes, Strin
 }
 
 #[async_dart(namespace = "accounts")]
-pub async fn vec_arg(contacts: Vec<data::Contact>) -> Result<Vec<data::Contact>, String> {
-  println!("\n[Rust] Received vec: {:?}", contacts);
+pub async fn vec_struct(values: Vec<data::Contact>) -> Result<Vec<data::Contact>, String> {
+  println!("\n[Rust] Received struct vec: {:?}", values);
 
-  Ok(contacts)
+  Ok(values)
 }
 
 #[async_dart(namespace = "accounts")]
@@ -283,6 +283,43 @@ pub async fn vec_int(values: Vec<i64>) -> Result<Vec<i64>, String> {
 #[async_dart(namespace = "accounts")]
 pub async fn vec_float(values: Vec<f64>) -> Result<Vec<f64>, String> {
   println!("\n[Rust] Received float vec: {:?}", values);
+
+  Ok(values)
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn vec_option_struct(
+  values: Vec<Option<data::Contact>>,
+) -> Result<Vec<Option<data::Contact>>, String> {
+  println!("\n[Rust] Received optional struct vec: {:?}", values);
+
+  Ok(values)
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn vec_option_string(values: Vec<Option<String>>) -> Result<Vec<Option<String>>, String> {
+  println!("\n[Rust] Received string option vec: {:?}", values);
+
+  Ok(values)
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn vec_option_bool(values: Vec<Option<bool>>) -> Result<Vec<Option<bool>>, String> {
+  println!("\n[Rust] Received bool option vec: {:?}", values);
+
+  Ok(values)
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn vec_option_int(values: Vec<Option<i64>>) -> Result<Vec<Option<i64>>, String> {
+  println!("\n[Rust] Received int option vec: {:?}", values);
+
+  Ok(values)
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn vec_option_float(values: Vec<Option<f64>>) -> Result<Vec<Option<f64>>, String> {
+  println!("\n[Rust] Received float option vec: {:?}", values);
 
   Ok(values)
 }

--- a/example/src/application/advanced.rs
+++ b/example/src/application/advanced.rs
@@ -260,6 +260,34 @@ pub async fn vec_arg(contacts: Vec<data::Contact>) -> Result<Vec<data::Contact>,
 }
 
 #[async_dart(namespace = "accounts")]
+pub async fn vec_string(values: Vec<String>) -> Result<Vec<String>, String> {
+  println!("\n[Rust] Received string vec: {:?}", values);
+
+  Ok(values)
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn vec_bool(values: Vec<bool>) -> Result<Vec<bool>, String> {
+  println!("\n[Rust] Received bool vec: {:?}", values);
+
+  Ok(values)
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn vec_int(values: Vec<i64>) -> Result<Vec<i64>, String> {
+  println!("\n[Rust] Received int vec: {:?}", values);
+
+  Ok(values)
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn vec_float(values: Vec<f64>) -> Result<Vec<f64>, String> {
+  println!("\n[Rust] Received float vec: {:?}", values);
+
+  Ok(values)
+}
+
+#[async_dart(namespace = "accounts")]
 pub async fn filter_arg(filter: data::Filter) -> Result<data::Contacts, String> {
   println!("\n[Rust] Received filter: {:?}", filter);
 

--- a/example/src/application/advanced.rs
+++ b/example/src/application/advanced.rs
@@ -175,7 +175,47 @@ pub async fn scalar_empty() -> Result<(), String> {
 }
 
 #[async_dart(namespace = "accounts")]
+pub async fn scalar_i8(val: i64) -> Result<i8, String> {
+  use std::convert::TryInto;
+
+  assert!(val == 123);
+  Ok(val.try_into().unwrap())
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn scalar_u8(val: i64) -> Result<u8, String> {
+  use std::convert::TryInto;
+
+  assert!(val == 123);
+  Ok(val.try_into().unwrap())
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn scalar_i16(val: i64) -> Result<i16, String> {
+  use std::convert::TryInto;
+
+  assert!(val == 123);
+  Ok(val.try_into().unwrap())
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn scalar_u16(val: i64) -> Result<u16, String> {
+  use std::convert::TryInto;
+
+  assert!(val == 123);
+  Ok(val.try_into().unwrap())
+}
+
+#[async_dart(namespace = "accounts")]
 pub async fn scalar_i32(val: i64) -> Result<i32, String> {
+  use std::convert::TryInto;
+
+  assert!(val == 123);
+  Ok(val.try_into().unwrap())
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn scalar_u32(val: i64) -> Result<u32, String> {
   use std::convert::TryInto;
 
   assert!(val == 123);

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -972,7 +972,12 @@ impl Function {
     let de;
     match ty[..] {
       ["String"] => "deserializer.deserializeString()",
+      ["i8"] => "deserializer.deserializeInt8()",
+      ["u8"] => "deserializer.deserializeUint8()",
+      ["i16"] => "deserializer.deserializeInt16()",
+      ["u16"] => "deserializer.deserializeUint16()",
       ["i32"] => "deserializer.deserializeInt32()",
+      ["u32"] => "deserializer.deserializeUint32()",
       ["i64"] => "deserializer.deserializeInt64()",
       ["f32"] => "deserializer.deserializeFloat32()",
       ["f64"] => "deserializer.deserializeFloat64()",

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -978,28 +978,24 @@ impl Function {
       ["f64"] => "deserializer.deserializeFloat64()",
       ["bool"] => "deserializer.deserializeBool()",
       ["()"] => "null",
-      ["Vec", ty] => {
+      ["Vec", "Option", ..] => {
         de = format!(
-          "(){{
-            final length = deserializer.deserializeLength();
-            return List.generate(length, (_i) => {});
-          }}()",
-          self.deserializer(&[ty], enum_tracer_registry, config)
+          "List.generate(deserializer.deserializeLength(), (_i) {{
+            if (deserializer.deserializeOptionTag()) {{
+              return {};
+            }}
+            return null;
+          }});",
+          self.deserializer(&ty[2..], enum_tracer_registry, config)
         );
         &de
       }
-      ["Vec", "Option", ty] => {
+      ["Vec", ..] => {
         de = format!(
-          "(){{
-            final length = deserializer.deserializeLength();
-            return List.generate(length, (_i) {{
-              if (deserializer.deserializeOptionTag()) {{
-                return {};
-              }}
-              return null;
-            }});
-          }}()",
-          self.deserializer(&[ty], enum_tracer_registry, config)
+          "List.generate(deserializer.deserializeLength(), (_i) {{
+            return {};
+          }});",
+          self.deserializer(&ty[1..], enum_tracer_registry, config)
         );
         &de
       }

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -982,9 +982,9 @@ impl Function {
         de = format!(
           "(){{
             final length = deserializer.deserializeLength();
-            return List.generate(length, (_i) => {}.deserialize(deserializer));
+            return List.generate(length, (_i) => {});
           }}()",
-          ty
+          self.deserializer(&vec![ty], enum_tracer_registry, config)
         );
         &de
       }

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -79,7 +79,7 @@ pub mod emitter;
 #[doc(hidden)]
 pub mod utils;
 
-use membrane_types::dart::dart_bare_type;
+use membrane_types::dart::dart_type;
 use membrane_types::heck::CamelCase;
 use serde_reflection::{ContainerFormat, Error, Registry, Samples, Tracer, TracerConfig};
 use std::{
@@ -754,9 +754,9 @@ impl Function {
         "Future"
       },
       return_type = if self.is_sync {
-        dart_bare_type(&self.return_type)
+        dart_type(&self.return_type)
       } else {
-        format!("<{}>", dart_bare_type(&self.return_type))
+        format!("<{}>", dart_type(&self.return_type))
       },
       fn_name = self.fn_name,
       fn_params = if self.dart_outer_params.is_empty() {

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -988,6 +988,21 @@ impl Function {
         );
         &de
       }
+      ["Vec", "Option", ty] => {
+        de = format!(
+          "(){{
+            final length = deserializer.deserializeLength();
+            return List.generate(length, (_i) {{
+              if (deserializer.deserializeOptionTag()) {{
+                return {};
+              }}
+              return null;
+            }});
+          }}()",
+          self.deserializer(&vec![ty], enum_tracer_registry, config)
+        );
+        &de
+      }
       ["Option", _ty] => {
         panic!(
           "Option is not supported as a bare return type. Return the inner type from {} instead",

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -754,7 +754,7 @@ impl Function {
         "Future"
       },
       return_type = if self.is_sync {
-        dart_bare_type(&self.return_type).to_string()
+        dart_bare_type(&self.return_type)
       } else {
         format!("<{}>", dart_bare_type(&self.return_type))
       },
@@ -965,7 +965,7 @@ impl Function {
 
   fn deserializer(
     &self,
-    ty: &Vec<&str>,
+    ty: &[&str],
     enum_tracer_registry: &Registry,
     config: &Membrane,
   ) -> String {
@@ -984,7 +984,7 @@ impl Function {
             final length = deserializer.deserializeLength();
             return List.generate(length, (_i) => {});
           }}()",
-          self.deserializer(&vec![ty], enum_tracer_registry, config)
+          self.deserializer(&[ty], enum_tracer_registry, config)
         );
         &de
       }
@@ -999,7 +999,7 @@ impl Function {
               return null;
             }});
           }}()",
-          self.deserializer(&vec![ty], enum_tracer_registry, config)
+          self.deserializer(&[ty], enum_tracer_registry, config)
         );
         &de
       }

--- a/membrane/tests/ui/single.rs
+++ b/membrane/tests/ui/single.rs
@@ -23,20 +23,16 @@ static RUNTIME: Runtime = Runtime {};
 pub async fn no_result() -> i32 {}
 
 #[async_dart(namespace = "a")]
-pub async fn no_result_bare_vec() -> Vec<i32> {}
-
-#[async_dart(namespace = "a")]
-pub async fn bare_vec() -> Result<Vec<i32>, String> {}
-
-#[async_dart(namespace = "a")]
 pub async fn bare_tuple() -> Result<(i32, i32), String> {}
 
 #[async_dart(namespace = "a")]
-pub async fn option() -> Result<Option<i32>, String> {}
+pub async fn option_success() -> Result<Option<i32>, String> {
+  Ok(Some(1))
+}
 
 #[async_dart(namespace = "a")]
-pub async fn one_success() -> Result<i32, String> {
-  Ok(10)
+pub async fn one_success() -> Result<Vec<i32>, String> {
+  Ok(vec![10])
 }
 
 #[sync_dart(namespace = "a")]

--- a/membrane/tests/ui/single.stderr
+++ b/membrane/tests/ui/single.stderr
@@ -4,34 +4,18 @@ error: expected enum `Result`
 23 | pub async fn no_result() -> i32 {}
    |                             ^^^
 
-error: expected enum `Result`
-  --> tests/ui/single.rs:26:38
-   |
-26 | pub async fn no_result_bare_vec() -> Vec<i32> {}
-   |                                      ^^^
-
-error: A vector may not be returned from an `async_dart` function. If a vector is needed return a struct containing the vector.
-  --> tests/ui/single.rs:29:35
-   |
-29 | pub async fn bare_vec() -> Result<Vec<i32>, String> {}
-   |                                   ^^^
-
 error: A tuple may not be returned from an `async_dart` function. If a tuple is needed return a struct containing the tuple.
-  --> tests/ui/single.rs:32:37
+  --> tests/ui/single.rs:25:1
    |
-32 | pub async fn bare_tuple() -> Result<(i32, i32), String> {}
-   |                                     ^
-
-error: expected a struct or scalar type
-  --> tests/ui/single.rs:35:33
+25 | #[async_dart(namespace = "a")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-35 | pub async fn option() -> Result<Option<i32>, String> {}
-   |                                 ^^^^^^
+   = note: this error originates in the attribute macro `async_dart` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: custom attribute panicked
-  --> tests/ui/single.rs:42:1
+  --> tests/ui/single.rs:38:1
    |
-42 | #[sync_dart(namespace = "a")]
+38 | #[sync_dart(namespace = "a")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: message: #[sync_dart] expected a return type of `Result<T, E>` found an emitter

--- a/membrane/tests/ui/stream.rs
+++ b/membrane/tests/ui/stream.rs
@@ -26,9 +26,6 @@ pub fn one_failure() -> impl Stream<i32, String> {}
 pub fn two_failure() -> impl Stream<Item = i32, String> {}
 
 #[async_dart(namespace = "a")]
-pub fn three_failure() -> impl Stream<Item = Result<Option<i32>, String>> {}
-
-#[async_dart(namespace = "a")]
 pub fn one_success() -> impl Stream<Item = Result<i32, String>> {
   futures::stream::iter(vec![])
 }

--- a/membrane/tests/ui/stream.stderr
+++ b/membrane/tests/ui/stream.stderr
@@ -9,9 +9,3 @@ error: expected enum `Result`
    |
 26 | pub fn two_failure() -> impl Stream<Item = i32, String> {}
    |                                            ^^^
-
-error: expected a struct or scalar type
-  --> tests/ui/stream.rs:29:53
-   |
-29 | pub fn three_failure() -> impl Stream<Item = Result<Option<i32>, String>> {}
-   |                                                     ^^^^^^

--- a/membrane_types/src/c.rs
+++ b/membrane_types/src/c.rs
@@ -1,4 +1,4 @@
-use crate::Input;
+use crate::{rust::flatten_types, Input};
 
 pub struct CHeaderTypes(Vec<String>);
 
@@ -9,7 +9,12 @@ impl From<&Vec<Input>> for CHeaderTypes {
     for input in inputs {
       stream.push(format!(
         "{c_type}{variable}",
-        c_type = c_type(&input.rust_type),
+        c_type = c_type(
+          &flatten_types(&input.ty, vec![])
+            .iter()
+            .map(|x| x.as_str())
+            .collect::<Vec<&str>>()
+        ),
         variable = &input.variable,
       ))
     }
@@ -24,18 +29,19 @@ impl From<CHeaderTypes> for Vec<String> {
   }
 }
 
-fn c_type(ty: &str) -> String {
-  match ty {
-    "String" => "const char *",
-    "i64" => "const signed long ",
-    "f64" => "const double ",
-    "bool" => "const uint8_t ",
-    serialized if !serialized.starts_with("Option<") => "const uint8_t *",
-    "Option<String>" => "const char *",
-    "Option<i64>" => "const signed long *",
-    "Option<f64>" => "const double *",
-    "Option<bool>" => "const uint8_t *",
-    serialized if serialized.starts_with("Option<") => "const uint8_t *",
+fn c_type(ty: &[&str]) -> String {
+  match ty[..] {
+    ["String"] => "const char *",
+    ["i64"] => "const signed long ",
+    ["f64"] => "const double ",
+    ["bool"] => "const uint8_t ",
+    ["Vec", ..] => "const uint8_t *",
+    [serialized, ..] if serialized != "Option" => "const uint8_t *",
+    ["Option", "String"] => "const char *",
+    ["Option", "i64"] => "const signed long *",
+    ["Option", "f64"] => "const double *",
+    ["Option", "bool"] => "const uint8_t *",
+    ["Option", _serialized] => "const uint8_t *",
     _ => unreachable!("[c_type] macro checks should make this code unreachable"),
   }
   .to_string()

--- a/membrane_types/src/c.rs
+++ b/membrane_types/src/c.rs
@@ -36,7 +36,7 @@ fn c_type(ty: &str) -> String {
     "Option<f64>" => "const double *",
     "Option<bool>" => "const uint8_t *",
     serialized if serialized.starts_with("Option<") => "const uint8_t *",
-    _ => unreachable!(),
+    _ => unreachable!("[c_type] macro checks should make this code unreachable"),
   }
   .to_string()
 }

--- a/membrane_types/src/dart.rs
+++ b/membrane_types/src/dart.rs
@@ -94,11 +94,11 @@ pub fn dart_type(types: &[&str]) -> String {
     ["bool"] => "bool",
     ["()"] => "void",
     ["Vec", "Option", ..] => {
-      ty = format!("List<{}?>", dart_type(&types[2..].to_vec()));
+      ty = format!("List<{}?>", dart_type(&types[2..]));
       &ty
     }
     ["Vec", ..] => {
-      ty = format!("List<{}>", dart_type(&types[1..].to_vec()));
+      ty = format!("List<{}>", dart_type(&types[1..]));
       &ty
     }
     _ => types[0],

--- a/membrane_types/src/dart.rs
+++ b/membrane_types/src/dart.rs
@@ -17,7 +17,7 @@ impl From<&Vec<Input>> for DartParams {
           &flatten_types(&input.ty, vec![])
             .iter()
             .map(|x| x.as_str())
-            .collect()
+            .collect::<Vec<&str>>()
         ),
         variable = &input.variable.to_mixed_case(),
       ))
@@ -39,7 +39,7 @@ impl From<&Vec<Input>> for DartTransforms {
           &flatten_types(&input.ty, vec![])
             .iter()
             .map(|x| x.as_str())
-            .collect(),
+            .collect::<Vec<&str>>(),
           &input.variable,
           &input.ty
         )
@@ -83,7 +83,7 @@ impl From<DartArgs> for Vec<String> {
   }
 }
 
-pub fn dart_bare_type<'a>(str_ty: &Vec<&'a str>) -> String {
+pub fn dart_bare_type(str_ty: &[&str]) -> String {
   let tmp;
   match str_ty[..] {
     ["String"] => "String",
@@ -106,7 +106,7 @@ pub fn dart_bare_type<'a>(str_ty: &Vec<&'a str>) -> String {
   .to_string()
 }
 
-fn dart_type<'a>(str_ty: &Vec<&str>) -> String {
+fn dart_type(str_ty: &[&str]) -> String {
   let ser_type;
   match str_ty[..] {
     ["String"] => "required String",
@@ -114,11 +114,11 @@ fn dart_type<'a>(str_ty: &Vec<&str>) -> String {
     ["f64"] => "required double",
     ["bool"] => "required bool",
     ["Vec", ty] => {
-      ser_type = format!("required List<{}>", dart_bare_type(&vec![ty]));
+      ser_type = format!("required List<{}>", dart_bare_type(&[ty]));
       &ser_type
     }
     ["Vec", "Option", ty] => {
-      ser_type = format!("required List<{}?>", dart_bare_type(&vec![ty]));
+      ser_type = format!("required List<{}?>", dart_bare_type(&[ty]));
       &ser_type
     }
     [serialized] if serialized != "Option" => {
@@ -138,7 +138,7 @@ fn dart_type<'a>(str_ty: &Vec<&str>) -> String {
   .to_string()
 }
 
-fn cast_dart_type_to_c(str_ty: &Vec<&str>, variable: &str, ty: &Type) -> String {
+fn cast_dart_type_to_c(str_ty: &[&str], variable: &str, ty: &Type) -> String {
   match ty {
     &syn::Type::Reference(_) => panic!(
       "{}",

--- a/membrane_types/src/dart.rs
+++ b/membrane_types/src/dart.rs
@@ -87,7 +87,12 @@ pub fn dart_type(types: &[&str]) -> String {
   let ty;
   match types[..] {
     ["String"] => "String",
+    ["i8"] => "int",
+    ["u8"] => "int",
+    ["i16"] => "int",
+    ["u16"] => "int",
     ["i32"] => "int",
+    ["u32"] => "int",
     ["i64"] => "int",
     ["f32"] => "double",
     ["f64"] => "double",

--- a/membrane_types/src/rust.rs
+++ b/membrane_types/src/rust.rs
@@ -69,10 +69,7 @@ impl From<RustArgs> for Vec<Ident> {
 
 pub fn flatten_types<'a>(ty: &syn::Type, mut types: Vec<String>) -> Vec<String> {
   match &ty {
-    syn::Type::Tuple(_expr) => {
-      types.push("()".to_string());
-      types
-    }
+    syn::Type::Tuple(_expr) => vec!["()".to_string()],
     syn::Type::Path(expr) => {
       let last = expr.path.segments.last().unwrap();
       types.push(last.ident.to_string());

--- a/membrane_types/src/rust.rs
+++ b/membrane_types/src/rust.rs
@@ -67,7 +67,7 @@ impl From<RustArgs> for Vec<Ident> {
   }
 }
 
-pub fn flatten_types<'a>(ty: &syn::Type, mut types: Vec<String>) -> Vec<String> {
+pub fn flatten_types(ty: &syn::Type, mut types: Vec<String>) -> Vec<String> {
   match &ty {
     syn::Type::Tuple(_expr) => vec!["()".to_string()],
     syn::Type::Path(expr) => {

--- a/membrane_types/src/rust.rs
+++ b/membrane_types/src/rust.rs
@@ -15,7 +15,12 @@ impl From<&Vec<Input>> for RustExternParams {
 
     for input in inputs {
       let variable = Ident::new(&input.variable, Span::call_site());
-      let c_type = rust_c_type(&input.rust_type);
+      let c_type = rust_c_type(
+        &flatten_types(&input.ty, vec![])
+          .iter()
+          .map(|x| x.as_str())
+          .collect::<Vec<&str>>(),
+      );
       stream.push(q!(#variable: #c_type))
     }
 
@@ -29,7 +34,14 @@ impl From<&Vec<Input>> for RustTransforms {
 
     for input in inputs {
       let variable = Ident::new(&input.variable, Span::call_site());
-      let cast = cast_c_type_to_rust(&input.rust_type, &input.variable, &input.ty);
+      let cast = cast_c_type_to_rust(
+        &flatten_types(&input.ty, vec![])
+          .iter()
+          .map(|x| x.as_str())
+          .collect::<Vec<&str>>(),
+        &input.variable,
+        &input.ty,
+      );
       stream.push(q!(let #variable = #cast;))
     }
 
@@ -90,51 +102,53 @@ pub fn flatten_types(ty: &syn::Type, mut types: Vec<String>) -> Vec<String> {
   }
 }
 
-fn rust_c_type(ty: &str) -> TokenStream2 {
-  match ty {
-    "String" => q!(*const ::std::os::raw::c_char),
-    "i64" => q!(::std::os::raw::c_long),
-    "f64" => q!(::std::os::raw::c_double),
-    "bool" => q!(::std::os::raw::c_char), // i8
-    serialized if !serialized.starts_with("Option<") => q!(*const u8),
-    "Option<String>" => q!(*const ::std::os::raw::c_char),
-    "Option<i64>" => q!(*const ::std::os::raw::c_long),
-    "Option<f64>" => q!(*const ::std::os::raw::c_double),
-    "Option<bool>" => q!(*const ::std::os::raw::c_char), // i8
-    serialized if serialized.starts_with("Option<") => q!(*const u8),
+fn rust_c_type(ty: &[&str]) -> TokenStream2 {
+  match ty[..] {
+    ["String"] => q!(*const ::std::os::raw::c_char),
+    ["i64"] => q!(::std::os::raw::c_long),
+    ["f64"] => q!(::std::os::raw::c_double),
+    ["bool"] => q!(::std::os::raw::c_char), // i8
+    ["Vec", ..] => q!(*const u8),
+    [serialized] if serialized != "Option" => q!(*const u8),
+    ["Option", "String"] => q!(*const ::std::os::raw::c_char),
+    ["Option", "i64"] => q!(*const ::std::os::raw::c_long),
+    ["Option", "f64"] => q!(*const ::std::os::raw::c_double),
+    ["Option", "bool"] => q!(*const ::std::os::raw::c_char), // i8
+    ["Option", _serialized] => q!(*const u8),
     _ => unreachable!("[rust_c_type] macro checks should make this code unreachable"),
   }
 }
 
-fn cast_c_type_to_rust(str_ty: &str, variable: &str, ty: &Type) -> TokenStream2 {
-  match str_ty {
-    "String" => {
+fn cast_c_type_to_rust(types: &[&str], variable: &str, ty: &Type) -> TokenStream2 {
+  match types[..] {
+    ["String"] => {
       let variable = Ident::new(variable, Span::call_site());
       q!(cstr!(#variable, panic!("invalid C string")).to_string())
     }
-    "i64" => {
+    ["i64"] => {
       let variable = Ident::new(variable, Span::call_site());
       q!(#variable)
     }
-    "f64" => {
+    ["f64"] => {
       let variable = Ident::new(variable, Span::call_site());
       q!(#variable)
     }
-    "bool" => {
+    ["bool"] => {
       let variable = Ident::new(variable, Span::call_site());
       q!(#variable != 0)
     }
-    serialized if !serialized.starts_with("Option<") => {
+    // this also handles Vec
+    [serialized, ..] if serialized != "Option" => {
       let variable_name = variable;
       let variable = Ident::new(variable, Span::call_site());
-      let deserialize = deserialize(variable, variable_name, ty, str_ty);
+      let deserialize = deserialize(variable, variable_name, ty, types[0]);
       q! {
         {
           #deserialize
         }
       }
     }
-    "Option<String>" => {
+    ["Option", "String"] => {
       let variable_name = variable;
       let variable = Ident::new(variable, Span::call_site());
       q! {
@@ -151,7 +165,7 @@ fn cast_c_type_to_rust(str_ty: &str, variable: &str, ty: &Type) -> TokenStream2 
         }
       }
     }
-    "Option<i64>" => {
+    ["Option", "i64"] => {
       let variable = Ident::new(variable, Span::call_site());
       q! {
         match unsafe { #variable.as_ref() } {
@@ -160,7 +174,7 @@ fn cast_c_type_to_rust(str_ty: &str, variable: &str, ty: &Type) -> TokenStream2 
         }
       }
     }
-    "Option<f64>" => {
+    ["Option", "f64"] => {
       let variable = Ident::new(variable, Span::call_site());
       q! {
         match unsafe { #variable.as_ref() } {
@@ -169,7 +183,7 @@ fn cast_c_type_to_rust(str_ty: &str, variable: &str, ty: &Type) -> TokenStream2 
         }
       }
     }
-    "Option<bool>" => {
+    ["Option", "bool"] => {
       let variable = Ident::new(variable, Span::call_site());
       q! {
         match unsafe { #variable.as_ref() } {
@@ -178,7 +192,7 @@ fn cast_c_type_to_rust(str_ty: &str, variable: &str, ty: &Type) -> TokenStream2 
         }
       }
     }
-    serialized if serialized.starts_with("Option<") => {
+    ["Option", _serialized] => {
       let variable_name = variable;
       let variable = Ident::new(variable, Span::call_site());
       let ty = extract_type_from_option(ty).unwrap();

--- a/membrane_types/src/rust.rs
+++ b/membrane_types/src/rust.rs
@@ -86,7 +86,7 @@ pub fn flatten_types<'a>(ty: &syn::Type, mut types: Vec<String>) -> Vec<String> 
         types
       }
     }
-    _ => unreachable!(),
+    _ => unreachable!("[flatten_types] macro checks should make this code unreachable"),
   }
 }
 
@@ -102,7 +102,7 @@ fn rust_c_type(ty: &str) -> TokenStream2 {
     "Option<f64>" => q!(*const ::std::os::raw::c_double),
     "Option<bool>" => q!(*const ::std::os::raw::c_char), // i8
     serialized if serialized.starts_with("Option<") => q!(*const u8),
-    _ => unreachable!(),
+    _ => unreachable!("[rust_c_type] macro checks should make this code unreachable"),
   }
 }
 
@@ -200,7 +200,7 @@ fn cast_c_type_to_rust(str_ty: &str, variable: &str, ty: &Type) -> TokenStream2 
       }
     }
 
-    _ => unreachable!(),
+    _ => unreachable!("[cast_c_type_to_rust] macro checks should make this code unreachable"),
   }
 }
 


### PR DESCRIPTION
Previously the recommended way to handle the following case:
```
#[async_dart(namespace = "example")]
pub async foo(data: Vec<i64>) -> Result<Vec<i64>, Error> {}
```
was to create a struct to serialize/deserialize the vector data `pub struct Wrapper(pub Vec<i64>);`. This pull request adds support for vectors with no wrapper needed. Nesting and optional values are also supported such as `Vec<Vec<Option<Vec<Option<i64>>>>`.