### PR TITLE
Refactor error handling to improve developer experience

### DIFF
--- a/membrane/tests/ui/single.rs
+++ b/membrane/tests/ui/single.rs
@@ -19,6 +19,19 @@ impl Runtime {
 
 static RUNTIME: Runtime = Runtime {};
 
+// attribute errors
+
+#[async_dart]
+pub async fn no_namespace() -> i32 {}
+
+#[async_dart(namespace = "a", foo = true)]
+pub async fn bad_option() -> i32 {}
+
+#[sync_dart(namespace = "a", os_thread = true)]
+pub async fn os_thread_option_used_in_sync_fn() -> i32 {}
+
+// return value errors
+
 #[async_dart(namespace = "a")]
 pub async fn no_result() -> i32 {}
 
@@ -26,18 +39,39 @@ pub async fn no_result() -> i32 {}
 pub async fn bare_tuple() -> Result<(i32, i32), String> {}
 
 #[async_dart(namespace = "a")]
-pub async fn option_success() -> Result<Option<i32>, String> {
-  Ok(Some(1))
-}
+pub async fn top_level_option() -> Option<String> {}
 
 #[async_dart(namespace = "a")]
-pub async fn one_success() -> Result<Vec<i32>, String> {
-  Ok(vec![10])
+pub async fn return_fn() -> Result<dyn Fn(), String> {}
+
+#[async_dart(namespace = "a")]
+pub async fn option_success() -> Result<Option<i32>, String> {
+  Ok(Some(1))
 }
 
 #[sync_dart(namespace = "a")]
 pub fn emitter_in_sync_return() -> impl membrane::emitter::Emitter<Result<String, String>> {
   membrane::emitter::emitter!()
+}
+
+// argument errors
+
+#[async_dart(namespace = "a")]
+pub async fn failing_arg(self) -> Result<(), String> {
+  Ok(())
+}
+
+#[async_dart(namespace = "a")]
+pub async fn bad_arg_type(one: i32) -> Result<i32, String> {}
+
+#[async_dart(namespace = "a")]
+pub async fn failing_arg_two(foo: &[i8]) -> Result<(), String> {
+  Ok(())
+}
+
+#[async_dart(namespace = "a")]
+pub async fn one_success() -> Result<Vec<i32>, String> {
+  Ok(vec![10])
 }
 
 fn main() {}

--- a/membrane/tests/ui/single.stderr
+++ b/membrane/tests/ui/single.stderr
@@ -1,21 +1,71 @@
-error: expected enum `Result`
-  --> tests/ui/single.rs:23:29
+error: #[async_dart] expects a `namespace` attribute
+  --> tests/ui/single.rs:24:1
    |
-23 | pub async fn no_result() -> i32 {}
-   |                             ^^^
-
-error: A tuple may not be returned from an `async_dart` function. If a tuple is needed return a struct containing the tuple.
-  --> tests/ui/single.rs:25:1
-   |
-25 | #[async_dart(namespace = "a")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+24 | #[async_dart]
+   | ^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `async_dart` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: custom attribute panicked
-  --> tests/ui/single.rs:38:1
+error: only `namespace=""`, `disable_logging=true`, `os_thread=true`, and `timeout=1000` are valid options
+  --> tests/ui/single.rs:27:1
    |
-38 | #[sync_dart(namespace = "a")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+27 | #[async_dart(namespace = "a", foo = true)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: message: #[sync_dart] expected a return type of `Result<T, E>` found an emitter
+   = note: this error originates in the attribute macro `async_dart` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `os_thread=true` is not a valid option for `sync_dart`
+  --> tests/ui/single.rs:30:1
+   |
+30 | #[sync_dart(namespace = "a", os_thread = true)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `sync_dart` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected enum `Result`
+  --> tests/ui/single.rs:36:29
+   |
+36 | pub async fn no_result() -> i32 {}
+   |                             ^^^
+
+error: A tuple may not be returned from an `async_dart` function. If a tuple is needed return a struct containing the tuple.
+  --> tests/ui/single.rs:39:37
+   |
+39 | pub async fn bare_tuple() -> Result<(i32, i32), String> {}
+   |                                     ^^^^^^^^^^
+
+error: expected enum `Result`
+  --> tests/ui/single.rs:42:36
+   |
+42 | pub async fn top_level_option() -> Option<String> {}
+   |                                    ^^^^^^
+
+error: expected a struct, vec, or scalar type but found `dyn Fn()`
+  --> tests/ui/single.rs:45:36
+   |
+45 | pub async fn return_fn() -> Result<dyn Fn(), String> {}
+   |                                    ^^^
+
+error: #[sync_dart] expected a return type of `Result<T, E>` found an emitter
+  --> tests/ui/single.rs:53:8
+   |
+53 | pub fn emitter_in_sync_return() -> impl membrane::emitter::Emitter<Result<String, String>> {
+   |        ^^^^^^^^^^^^^^^^^^^^^^
+
+error: not a supported argument type for Dart interop
+  --> tests/ui/single.rs:60:26
+   |
+60 | pub async fn failing_arg(self) -> Result<(), String> {
+   |                          ^^^^
+
+error: not a supported argument type for Dart interop, please use i64 instead.
+  --> tests/ui/single.rs:65:32
+   |
+65 | pub async fn bad_arg_type(one: i32) -> Result<i32, String> {}
+   |                                ^^^
+
+error: not a supported argument type for Dart interop
+  --> tests/ui/single.rs:68:35
+   |
+68 | pub async fn failing_arg_two(foo: &[i8]) -> Result<(), String> {
+   |                                   ^^^^^

--- a/membrane_macro/src/lib.rs
+++ b/membrane_macro/src/lib.rs
@@ -464,11 +464,10 @@ pub fn dart_enum(attrs: TokenStream, input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn emitter(_item: TokenStream) -> TokenStream {
-  quote! {
-    {
-      use ::membrane::emitter::Emitter;
-      ::membrane::emitter::Handle::new(_membrane_port)
-    }
-  }
-  .into()
+  "{
+    use ::membrane::emitter::Emitter;
+    ::membrane::emitter::Handle::new(_membrane_port)
+  }"
+  .parse()
+  .unwrap()
 }

--- a/membrane_macro/src/lib.rs
+++ b/membrane_macro/src/lib.rs
@@ -8,6 +8,7 @@ use options::{extract_options, Options};
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
+use std::convert::TryFrom;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::{parse_macro_input, AttributeArgs, Block, Ident, Token, Type};
 
@@ -91,18 +92,49 @@ pub fn sync_dart(attrs: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 fn dart_impl(attrs: TokenStream, input: TokenStream, sync: bool) -> TokenStream {
-  let Options {
-    namespace,
-    disable_logging,
-    timeout,
-    os_thread,
-  } = extract_options(
+  let options = match extract_options(
     parse_macro_input!(attrs as AttributeArgs),
     Options::default(),
     sync,
-  );
+  ) {
+    Ok(options) => options,
+    Err(err) => {
+      return syn::Error::new(Span::call_site(), err)
+        .to_compile_error()
+        .into();
+    }
+  };
+
+  // get the most helpful span we can, either the function name if we can find it or else the beginning of that line
+  let span: Span = if let Some(tree) = input
+    .clone()
+    .into_iter()
+    .take_while(|x| matches!(x, proc_macro::TokenTree::Ident { .. }))
+    .last()
+  {
+    tree.span().into()
+  } else if let Some(tree) = input.clone().into_iter().next() {
+    tree.span().into()
+  } else {
+    Span::call_site()
+  };
 
   let input_two = input.clone();
+  let repr_dart = parse_macro_input!(input as ReprDart);
+
+  match to_token_stream(repr_dart, input_two, sync, span, options) {
+    Ok(tokens) => tokens,
+    Err(err) => err.to_compile_error().into(),
+  }
+}
+
+fn to_token_stream(
+  repr_dart: ReprDart,
+  input: TokenStream,
+  sync: bool,
+  span: Span,
+  options: Options,
+) -> Result<TokenStream> {
   let ReprDart {
     fn_name,
     output_style,
@@ -110,40 +142,51 @@ fn dart_impl(attrs: TokenStream, input: TokenStream, sync: bool) -> TokenStream 
     error,
     inputs,
     ..
-  } = parse_macro_input!(input as ReprDart);
+  } = repr_dart;
+
+  let Options {
+    namespace,
+    disable_logging,
+    timeout,
+    os_thread,
+  } = options;
 
   let mut functions = TokenStream::new();
 
   match output_style {
     OutputStyle::StreamEmitterSerialized | OutputStyle::EmitterSerialized => {
-      functions.extend(parsers::add_port_to_args(input_two))
+      functions.extend(parsers::add_port_to_args(input))
     }
     _ => {
-      functions.extend(input_two);
+      functions.extend(input);
     }
   }
 
   let rust_outer_params: Vec<TokenStream2> = if sync {
-    RustExternParams::from(&inputs).into()
+    RustExternParams::try_from(&inputs)?.into()
   } else {
     vec![
       vec![quote! {membrane_port: i64}],
-      RustExternParams::from(&inputs).into(),
+      RustExternParams::try_from(&inputs)?.into(),
     ]
     .concat()
   };
-  let rust_transforms: Vec<TokenStream2> = RustTransforms::from(&inputs).into();
+  let rust_transforms: Vec<TokenStream2> = RustTransforms::try_from(&inputs)?.into();
   let rust_inner_args: Vec<Ident> = RustArgs::from(&inputs).into();
 
-  let c_header_types: Vec<String> = CHeaderTypes::from(&inputs).into();
+  let c_header_types: Vec<String> = CHeaderTypes::try_from(&inputs)?.into();
 
-  let dart_outer_params: Vec<String> = DartParams::from(&inputs).into();
-  let dart_transforms: Vec<String> = DartTransforms::from(&inputs).into();
+  let dart_outer_params: Vec<String> = DartParams::try_from(&inputs)?.into();
+  let dart_transforms: Vec<String> = DartTransforms::try_from(&inputs)?.into();
   let dart_inner_args: Vec<String> = DartArgs::from(&inputs).into();
 
   let return_statement = match output_style {
     OutputStyle::EmitterSerialized | OutputStyle::StreamEmitterSerialized if sync => {
-      panic!("#[sync_dart] expected a return type of `Result<T, E>` found an emitter");
+      syn::Error::new(
+        span,
+        "#[sync_dart] expected a return type of `Result<T, E>` found an emitter",
+      )
+      .into_compile_error()
     }
     OutputStyle::EmitterSerialized | OutputStyle::StreamEmitterSerialized => quote! {
       let membrane_emitter = #fn_name(membrane_port, #(#rust_inner_args),*);
@@ -274,10 +317,10 @@ fn dart_impl(attrs: TokenStream, input: TokenStream, sync: bool) -> TokenStream 
   ]
   .contains(&output_style);
 
-  let types = flatten_types(&output, vec![]);
+  let types = flatten_types(&output, vec![])?;
   let return_type = quote! { vec![#(#types),*] };
 
-  let types = flatten_types(&error, vec![]);
+  let types = flatten_types(&error, vec![])?;
   let error_type = quote! { vec![#(#types),*] };
 
   let rust_arg_types = inputs
@@ -335,7 +378,7 @@ fn dart_impl(attrs: TokenStream, input: TokenStream, sync: bool) -> TokenStream 
   ))]
   functions.extend::<TokenStream>(_deferred_trace.into());
 
-  functions
+  Ok(functions)
 }
 
 #[derive(Debug)]
@@ -357,11 +400,18 @@ impl Parse for ReprDartEnum {
 
 #[proc_macro_attribute]
 pub fn dart_enum(attrs: TokenStream, input: TokenStream) -> TokenStream {
-  let Options { namespace, .. } = extract_options(
+  let Options { namespace, .. } = match extract_options(
     parse_macro_input!(attrs as AttributeArgs),
     Options::default(),
     false,
-  );
+  ) {
+    Ok(options) => options,
+    Err(err) => {
+      return syn::Error::new(Span::call_site(), err)
+        .to_compile_error()
+        .into();
+    }
+  };
 
   let mut variants = TokenStream::new();
   variants.extend(input.clone());
@@ -414,7 +464,11 @@ pub fn dart_enum(attrs: TokenStream, input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn emitter(_item: TokenStream) -> TokenStream {
-  "::membrane::emitter::Handle::new(_membrane_port)"
-    .parse()
-    .unwrap()
+  quote! {
+    {
+      use ::membrane::emitter::Emitter;
+      ::membrane::emitter::Handle::new(_membrane_port)
+    }
+  }
+  .into()
 }

--- a/membrane_macro/src/options.rs
+++ b/membrane_macro/src/options.rs
@@ -68,9 +68,9 @@ pub(crate) fn extract_options(
 }
 
 fn invalid_option(macr: &str, opt: &str) -> Result<Options, String> {
-  return Err(format!(
+  Err(format!(
     "`{opt}` is not a valid option for `{m}`",
     m = macr,
     opt = opt
-  ));
+  ))
 }

--- a/membrane_macro/src/options.rs
+++ b/membrane_macro/src/options.rs
@@ -13,7 +13,7 @@ pub(crate) fn extract_options(
   mut input: Vec<NestedMeta>,
   mut options: Options,
   sync: bool,
-) -> Options {
+) -> Result<Options, String> {
   let option = match input.pop() {
     Some(NestedMeta::Meta(Meta::NameValue(MetaNameValue { path, lit, .. }))) => {
       let ident = path.get_ident().unwrap().clone();
@@ -36,40 +36,41 @@ pub(crate) fn extract_options(
       options
     }
     Some((ident, _)) if ident == "os_thread" && sync => {
-      invalid_option("sync_dart", "os_thread=true")
+      return invalid_option("sync_dart", "os_thread=true");
     }
     Some((ident, Lit::Bool(val))) if ident == "os_thread" => {
       options.os_thread = val.value();
       options
     }
     Some(_) if sync => {
-      panic!(r#"#[sync_dart] only `namespace=""` and `disable_logging=true` are valid options"#);
+      return Err(
+        r#"only `namespace=""` and `disable_logging=true` are valid options"#.to_string(),
+      );
     }
     Some(_) => {
-      panic!(
-        r#"#[async_dart] only `namespace=""`, `disable_logging=true`, `os_thread=true`, and `timeout=1000` are valid options"#
-      );
+      return Err(
+        r#"only `namespace=""`, `disable_logging=true`, `os_thread=true`, and `timeout=1000` are valid options"#.to_string());
     }
     None => {
       // we've iterated over all options and didn't find a namespace (required)
       if options.namespace.is_empty() {
-        panic!(
+        return Err(format!(
           "#[{}] expects a `namespace` attribute",
           if sync { "sync_dart" } else { "async_dart" }
-        );
+        ));
       }
 
-      return options;
+      return Ok(options);
     }
   };
 
   extract_options(input, options, sync)
 }
 
-fn invalid_option(macr: &str, opt: &str) -> ! {
-  panic!(
-    "#[{m}] `{opt}` is not a valid option for `{m}`",
+fn invalid_option(macr: &str, opt: &str) -> Result<Options, String> {
+  return Err(format!(
+    "`{opt}` is not a valid option for `{m}`",
     m = macr,
     opt = opt
-  );
+  ));
 }


### PR DESCRIPTION
Previously some cases were configured to panic to show the developer an error. Now we show a nice compile error with a span highlighting the code that is wrong.
![Screenshot from 2022-07-14 17-04-06](https://user-images.githubusercontent.com/322706/179097130-d9a98c6c-d533-41f2-9c1b-cd8267b1ee8d.png)

