### PR TITLE
Update ffigen

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@1.49.0
+      - uses: dtolnay/rust-toolchain@1.54.0
       - run: cargo build --verbose --features c-example --manifest-path membrane/Cargo.toml
   build-stable:
     name: build and test stable

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "dart.runPubGetOnPubspecChanges": false,
+}

--- a/README.md
+++ b/README.md
@@ -39,49 +39,8 @@
     * `apt-get install libclang-dev`
   * MacOS
     * `brew install llvm`
-  * MacOS M1
-    * there's a couple more steps, see below
 
 On Linux ffigen looks for libclang at `/usr/lib/llvm-11/lib/libclang.so` so you may need to symlink to the version specific library: `ln -s /usr/lib/llvm-11/lib/libclang.so.1 /usr/lib/llvm-11/lib/libclang.so`.
-
-On MacOS M1, ffigen still uses llvm for x86 architecture so far, while M1 is arm64: you might get an error mentioning *incompatible architecture (have 'arm64', need 'x86_64')*.
-
-<details>
-<summary>click & follow steps</summary>
-
-Essentially, you will need to install x86_64 variants of tools.
-Grab a coffee, this might take a while :coffee:
-
-- Rosetta2 (optional, only if asked)
-- Rust toolchain
-  ```sh
-  rustup target add x86_64-apple-darwin
-  ```
-- brew
-  ```sh
-  arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-  ```
-- llvm
-  ```sh
-  arch -x86_64 /usr/local/bin/brew install llvm
-  ```
-  ⚠️ if asked to install additional packages,
-  just follow recommendations in the console, e.g. :
-  ```sh
-  arch -x86_64 /usr/local/bin/brew install python@3.10
-  ```
-- ffi
-  ```sh
-  arch -x86_64 sudo gem install ffi
-  ```
-- finally run!
-  ```sh
-  # MEMBRANE_LLVM_PATHS must be set to folder's path
-  # where llvm for x86_64 is installed
-  export MEMBRANE_LLVM_PATHS=/usr/local/opt/llvm && cargo run --target=x86_64-apple-darwin
-  ```
-
-</details>
 
 ## Usage
 

--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -97,7 +97,7 @@ void main() {
             four: true,
             five: Arg(value: 20)),
         equals(high));
-  }, skip: true);
+  });
 
   test('can call a function that returns a scalar value', () async {
     final accounts = AccountsApi();

--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -97,7 +97,7 @@ void main() {
             four: true,
             five: Arg(value: 20)),
         equals(high));
-  });
+  }, skip: true);
 
   test('can call a function that returns a scalar value', () async {
     final accounts = AccountsApi();

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -464,24 +464,24 @@ uint8_t membrane_free_membrane_vec(int64_t len, const void *ptr);
 
     if let Ok(old) = std::fs::read_to_string(&path) {
       let pubspec = old
-      .lines()
-      .map(|ln| {
-        if ln.contains("name:") {
-          format!("name: {}", package_name)
-        } else if ln.contains("sdk:") {
-          // ffigen >= 5 requires dart >= 2.17, so replace dart version from serde-reflection
-          "  sdk: '>=2.17.0 <3.0.0'".to_owned()
-        } else {
-          ln.to_owned()
-        }
-      })
-      .chain([
-        "  logging: ^1.0.2\n".to_owned(),
-        "dev_dependencies:".to_owned(),
-        "  ffigen: ^6.0.1\n".to_owned()
-      ])
-      .collect::<Vec<String>>()
-      .join("\n");
+        .lines()
+        .map(|ln| {
+          if ln.contains("name:") {
+            format!("name: {}", package_name)
+          } else if ln.contains("sdk:") {
+            // ffigen >= 5 requires dart >= 2.17, so replace dart version from serde-reflection
+            "  sdk: '>=2.17.0 <3.0.0'".to_owned()
+          } else {
+            ln.to_owned()
+          }
+        })
+        .chain([
+          "  logging: ^1.0.2\n".to_owned(),
+          "dev_dependencies:".to_owned(),
+          "  ffigen: ^6.0.1\n".to_owned(),
+        ])
+        .collect::<Vec<String>>()
+        .join("\n");
 
       std::fs::write(path, pubspec).expect("pubspec could not be written");
       let _ = std::fs::remove_file(self.destination.join("pubspec.lock"));

--- a/membrane_types/src/c.rs
+++ b/membrane_types/src/c.rs
@@ -35,13 +35,13 @@ impl From<CHeaderTypes> for Vec<String> {
 fn c_type(ty: &[&str], type_: &syn::Type) -> syn::Result<String> {
   let type_ = match ty[..] {
     ["String"] => "const char *",
-    ["i64"] => "const signed long ",
+    ["i64"] => "const int64_t ",
     ["f64"] => "const double ",
     ["bool"] => "const uint8_t ",
     ["Vec", ..] => "const uint8_t *",
     [serialized, ..] if serialized != "Option" => "const uint8_t *",
     ["Option", "String"] => "const char *",
-    ["Option", "i64"] => "const signed long *",
+    ["Option", "i64"] => "const int64_t *",
     ["Option", "f64"] => "const double *",
     ["Option", "bool"] => "const uint8_t *",
     ["Option", _serialized] => "const uint8_t *",

--- a/membrane_types/src/dart.rs
+++ b/membrane_types/src/dart.rs
@@ -241,7 +241,7 @@ fn cast_dart_type_to_c(types: &[&str], variable: &str, ty: &Type) -> syn::Result
       if ({variable} == null) {{
         return nullptr;
       }}
-      final ptr = calloc<Int64>();
+      final ptr = calloc<Long>();
       _toFree.add(ptr);
       ptr.asTypedList(1).setAll(0, [{variable}]);
       return ptr;

--- a/membrane_types/src/dart.rs
+++ b/membrane_types/src/dart.rs
@@ -241,7 +241,7 @@ fn cast_dart_type_to_c(types: &[&str], variable: &str, ty: &Type) -> syn::Result
       if ({variable} == null) {{
         return nullptr;
       }}
-      final ptr = calloc<Long>();
+      final ptr = calloc<Int64>();
       _toFree.add(ptr);
       ptr.asTypedList(1).setAll(0, [{variable}]);
       return ptr;

--- a/membrane_types/src/dart.rs
+++ b/membrane_types/src/dart.rs
@@ -183,7 +183,7 @@ fn cast_dart_type_to_c(types: &[&str], variable: &str, ty: &Type) -> syn::Result
     ["String"] => {
       format!(
         r#"(){{
-          final ptr = {variable}.toNativeUtf8().cast<Int8>();
+          final ptr = {variable}.toNativeUtf8().cast<Char>();
           _toFree.add(ptr);
           return ptr;
         }}()"#,
@@ -217,7 +217,7 @@ fn cast_dart_type_to_c(types: &[&str], variable: &str, ty: &Type) -> syn::Result
       if ({variable} == null) {{
         return nullptr;
       }}
-      final ptr = {variable}.toNativeUtf8().cast<Int8>();
+      final ptr = {variable}.toNativeUtf8().cast<Char>();
       _toFree.add(ptr);
       return ptr;
     }}()"#,


### PR DESCRIPTION
<details>
<summary>Help me Jerel, you're my only hope.</summary>

![Save me Jerel](https://c.tenor.com/94c-LWTF2b0AAAAC/leia-youre-my-only-hope.gif)

</details>

I've gone down a bit of a rabbit hole trying to get M1 support without resorting to hacks like symlinking the Homebrew llvm.
Latest `ffigen` works great on the M1, but we've got some membrane type issues to iron out.

Tests are allllllmost passing, as seen in https://github.com/jerel/membrane/commit/35b8da1e8982805a1ed91c487a96f9e896617e80

Without the test in that commit skipped, the first error we get is (https://github.com/jerel/membrane/commit/1ea6cdd9b03ee9f7602adb95c9ab0eb3463251f7)
```bash
00:00 +6 -1: can call a function with optional args with none of the args or all of the args [E]
  type 'Pointer<Int64>' is not a subtype of type 'Pointer<Long>' of 'two'
  package:dart_example/accounts.dart 1928:31  AccountsApi.optionsDemo
  test/main_test.dart 79:24                   main.<fn>
```

Okay. Easy enough, right?
Change `Int64` to `Long` (https://github.com/jerel/membrane/commit/3219c7f9d5e8f4e81f0953a2818d39242897a205).

Now the fun error happens.
```bash
00:00 +0 -1: loading test/main_test.dart [E]
  Failed to load "test/main_test.dart":
  lib/accounts.dart:1887:11: Error: The method 'asTypedList' isn't defined for the class 'Pointer<Long>'.
   - 'Pointer' is from 'dart:ffi'.
   - 'Long' is from 'dart:ffi'.
  Try correcting the name to the name of an existing method, or defining a method named 'asTypedList'.
        ptr.asTypedList(1).setAll(0, [two]);
            ^^^^^^^^^^^
```

Digging in, it looks like there is no `extension LongPointer on Pointer<Long>` like there is for [`extension Int64Pointer on Pointer<Int64>`](https://github.com/dart-lang/sdk/blob/main/sdk/lib/ffi/ffi.dart#L281-L309) and most of the other types.
We can see where they recently added the [`extension BoolPointer`](https://github.com/dart-lang/sdk/commit/757c2b82ce3898021e530d15981d8033a3999bac) during some native type work.

Do we need a feature request to the Dart SDK?
And then we will wait for another language release?

I'm not entirely sure why we need the `asTypedList` part.
Is there a way we can work around the lack of it?

Potential other solution is finding some way to get the bindings to generate with `Int64` instead of `Long` for Rust `i64`.