### PR TITLE
Add support for both native Dart enums and class enums at the same time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,9 +855,8 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978215316c564fd719681f0f0dc60153274a8aae2a5c5ad694a12c19c8738912"
+version = "0.23.0"
+source = "git+https://github.com/jerel/serde-reflection?rev=04be37b#04be37b8f26ca9f138951d2c11e191de3e0f1375"
 dependencies = [
  "bcs",
  "bincode",
@@ -876,8 +875,7 @@ dependencies = [
 [[package]]
 name = "serde-reflection"
 version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
+source = "git+https://github.com/jerel/serde-reflection?rev=04be37b#04be37b8f26ca9f138951d2c11e191de3e0f1375"
 dependencies = [
  "once_cell",
  "serde",

--- a/dart_example/test/enum_test.dart
+++ b/dart_example/test/enum_test.dart
@@ -7,7 +7,8 @@ import 'package:dart_example/accounts.dart';
 // defaults to `.with_c_style_enums(true)` and consequently expects `Status.active` enums.
 // You may accomplish this by modifying generator.rs and then running `cargo run`
 void main() {
-  test('can handle a class enum', () async {
+  test('can handle a class enum when `with_c_style_enums` is set to `false`',
+      () async {
     final accounts = AccountsApi();
     expect((await accounts.enumReturn(status: StatusActiveItem())),
         equals(StatusActiveItem()));

--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -323,6 +323,14 @@ void main() {
         isNot(equals(Status.active)));
   });
 
+  test('can receive a complex data enum', () async {
+    final accounts = AccountsApi();
+    expect(
+        (await accounts.enumData()),
+        equals(ReportsReportsItem(
+            value: ReportsNameItem(value: "Example Report"))));
+  });
+
   test('can fetch a vector from a separate namespace', () async {
     final locations = LocationsApi();
     expect(

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -778,9 +778,8 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978215316c564fd719681f0f0dc60153274a8aae2a5c5ad694a12c19c8738912"
+version = "0.23.0"
+source = "git+https://github.com/jerel/serde-reflection?rev=04be37b#04be37b8f26ca9f138951d2c11e191de3e0f1375"
 dependencies = [
  "bcs",
  "bincode",
@@ -799,8 +798,7 @@ dependencies = [
 [[package]]
 name = "serde-reflection"
 version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
+source = "git+https://github.com/jerel/serde-reflection?rev=04be37b#04be37b8f26ca9f138951d2c11e191de3e0f1375"
 dependencies = [
  "once_cell",
  "serde",

--- a/example/src/application/advanced.rs
+++ b/example/src/application/advanced.rs
@@ -423,6 +423,12 @@ pub async fn enum_return(status: data::Status) -> Result<data::Status, String> {
   Ok(status)
 }
 
+#[async_dart(namespace = "accounts")]
+pub async fn enum_data() -> Result<data::Reports, String> {
+  let reports = data::Reports::Reports(Box::new(data::Reports::Name("Example Report".to_string())));
+  Ok(reports)
+}
+
 #[async_dart(namespace = "accounts", timeout = 100)]
 pub async fn slow_function(sleep_for: i64) -> Result<(), String> {
   use tokio::time::{sleep, Duration};

--- a/example/src/data.rs
+++ b/example/src/data.rs
@@ -10,6 +10,14 @@ pub enum Status {
   Active,
 }
 
+#[dart_enum(namespace = "accounts")]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum Reports {
+  None,
+  Name(String),
+  Reports(Box<Self>),
+}
+
 impl Default for Status {
   fn default() -> Self {
     Status::Pending

--- a/membrane/Cargo.toml
+++ b/membrane/Cargo.toml
@@ -28,8 +28,8 @@ membrane_macro = {version = "0.5", path = "../membrane_macro"}
 membrane_types = {version = "0.3", path = "../membrane_types"}
 regex = "1.5"
 serde = {version = "1.0", features = ["derive"]}
-serde-generate = "0.22"
-serde-reflection = "0.3"
+serde-generate = {git = "https://github.com/jerel/serde-reflection", rev = "04be37b"}
+serde-reflection = {git = "https://github.com/jerel/serde-reflection", rev = "04be37b"}
 
 [dev-dependencies]
 example = {path = "../example", features = ["c-example"]}

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -497,6 +497,7 @@ uint8_t membrane_free_membrane_vec(int64_t len, const void *ptr);
           }
         })
         .chain(vec![
+          "  ffi: ^2.0.0\n".to_owned(),
           "  logging: ^1.0.2\n".to_owned(),
           "dev_dependencies:".to_owned(),
           "  ffigen: ^6.0.1\n".to_owned(),

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -486,6 +486,7 @@ uint8_t membrane_free_membrane_vec(int64_t len, const void *ptr);
     if let Ok(old) = std::fs::read_to_string(&path) {
       let pubspec = old
         .lines()
+        .filter(|l| !l.is_empty())
         .map(|ln| {
           if ln.contains("name:") {
             format!("name: {}", package_name)
@@ -497,8 +498,8 @@ uint8_t membrane_free_membrane_vec(int64_t len, const void *ptr);
           }
         })
         .chain(vec![
-          "  ffi: ^2.0.0\n".to_owned(),
-          "  logging: ^1.0.2\n".to_owned(),
+          "  ffi: ^2.0.0".to_owned(),
+          "  logging: ^1.0.2".to_owned(),
           "dev_dependencies:".to_owned(),
           "  ffigen: ^6.0.1\n".to_owned(),
         ])

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -81,7 +81,9 @@ pub mod utils;
 
 use membrane_types::dart::dart_type;
 use membrane_types::heck::CamelCase;
-use serde_reflection::{ContainerFormat, Error, Registry, Samples, Tracer, TracerConfig};
+use serde_reflection::{
+  ContainerFormat, Error, Registry, Samples, Tracer, TracerConfig, VariantFormat,
+};
 use std::{
   collections::HashMap,
   io::Write,
@@ -1019,7 +1021,10 @@ impl Function {
       }
       [ty, ..] => {
         de = match enum_tracer_registry.get(ty) {
-          Some(ContainerFormat::Enum { .. }) if config.c_style_enums => {
+          Some(ContainerFormat::Enum(variants))
+            if config.c_style_enums
+              && variants.values().all(|f| f.value == VariantFormat::Unit) =>
+          {
             format!("{}Extension.deserialize(deserializer)", ty)
           }
           _ => format!("{}.deserialize(deserializer)", ty),

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -440,6 +440,25 @@ uint8_t membrane_free_membrane_vec(int64_t len, const void *ptr);
       panic!("dart ffigen returned an error");
     }
 
+    // TODO, this is a temporary hack to get around ffigen bug https://github.com/dart-lang/ffigen/issues/384
+    let path = self.destination.join("lib/src/ffi_bindings.dart");
+    let mut bindings = std::fs::read_to_string(&path).unwrap();
+    let vecs = regex::RegexBuilder::new(r#"^\s*int membrane_free_membrane_vec\d+\(.*?>\(\);\s*$"#)
+      .multi_line(true)
+      .dot_matches_new_line(true)
+      .build()
+      .unwrap();
+    let tasks =
+      regex::RegexBuilder::new(r#"^\s*int membrane_cancel_membrane_task\d+\(.*?>\(\);\s*$"#)
+        .multi_line(true)
+        .dot_matches_new_line(true)
+        .build()
+        .unwrap();
+    bindings = vecs.replace_all(&bindings, "").to_string();
+    bindings = tasks.replace_all(&bindings, "").to_string();
+    std::fs::write(path, bindings).expect("ffi_bindings.dart could not be written");
+    // end ffigen workaround
+
     self
   }
 


### PR DESCRIPTION
Previously a project would generate all classes if `project.with_c_style_enums(false)` was set or all Dart enums if it was `true`. This change makes `project.with_c_style_enums(true)` (the default) behave such that it generates Dart enums for simple Rust enums and generates classes for Rust enums that contain data.