### PR TITLE
Improve support for `Option` params and returns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,8 +855,9 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.23.0"
-source = "git+https://github.com/jerel/serde-reflection?rev=04be37b#04be37b8f26ca9f138951d2c11e191de3e0f1375"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30f6496661c4b50af439d30e60c496c582aa98e55b7686a8d2c274b3f2a67d36"
 dependencies = [
  "bcs",
  "bincode",
@@ -875,7 +876,8 @@ dependencies = [
 [[package]]
 name = "serde-reflection"
 version = "0.3.6"
-source = "git+https://github.com/jerel/serde-reflection?rev=04be37b#04be37b8f26ca9f138951d2c11e191de3e0f1375"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
 dependencies = [
  "once_cell",
  "serde",

--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -285,6 +285,20 @@ void main() {
         equals([1.0, 2.1, null]));
   });
 
+  test('can handle an optional vec arg', () async {
+    final accounts = AccountsApi();
+    expect((await accounts.optionalVecArg(values: [1.0, 2.1])), equals(true));
+
+    expect((await accounts.optionalVecArg()), equals(false));
+  });
+
+  test('can handle an optional float arg', () async {
+    final accounts = AccountsApi();
+    expect((await accounts.optionalFloatArg(value: 1.0)), equals(true));
+
+    expect((await accounts.optionalFloatArg()), equals(false));
+  });
+
   test('can pass a tuple arg containing a vec of structs', () async {
     final accounts = AccountsApi();
     expect(

--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -285,18 +285,19 @@ void main() {
         equals([1.0, 2.1, null]));
   });
 
-  test('can handle an optional vec arg', () async {
+  test('can handle an optional vec arg with optional return value', () async {
     final accounts = AccountsApi();
-    expect((await accounts.optionalVecArg(values: [1.0, 2.1])), equals(true));
+    expect((await accounts.optionalVecArg(values: [1.0, 2.1])),
+        equals([1.0, 2.1]));
 
-    expect((await accounts.optionalVecArg()), equals(false));
+    expect((await accounts.optionalVecArg()), equals(null));
   });
 
-  test('can handle an optional float arg', () async {
+  test('can handle an optional float arg with optional return value', () async {
     final accounts = AccountsApi();
-    expect((await accounts.optionalFloatArg(value: 1.0)), equals(true));
+    expect((await accounts.optionalFloatArg(value: 1.0)), equals(1.0));
 
-    expect((await accounts.optionalFloatArg()), equals(false));
+    expect((await accounts.optionalFloatArg()), equals(null));
   });
 
   test('can pass a tuple arg containing a vec of structs', () async {

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -778,8 +778,9 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.23.0"
-source = "git+https://github.com/jerel/serde-reflection?rev=04be37b#04be37b8f26ca9f138951d2c11e191de3e0f1375"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30f6496661c4b50af439d30e60c496c582aa98e55b7686a8d2c274b3f2a67d36"
 dependencies = [
  "bcs",
  "bincode",
@@ -798,7 +799,8 @@ dependencies = [
 [[package]]
 name = "serde-reflection"
 version = "0.3.6"
-source = "git+https://github.com/jerel/serde-reflection?rev=04be37b#04be37b8f26ca9f138951d2c11e191de3e0f1375"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
 dependencies = [
  "once_cell",
  "serde",

--- a/example/src/application/advanced.rs
+++ b/example/src/application/advanced.rs
@@ -384,21 +384,13 @@ pub async fn vec_option_float(values: Vec<Option<f64>>) -> Result<Vec<Option<f64
 }
 
 #[async_dart(namespace = "accounts")]
-pub async fn optional_vec_arg(values: Option<Vec<f64>>) -> Result<bool, String> {
-  if values.is_some() {
-    Ok(true)
-  } else {
-    Ok(false)
-  }
+pub async fn optional_vec_arg(values: Option<Vec<f64>>) -> Result<Option<Vec<f64>>, String> {
+  Ok(values)
 }
 
 #[async_dart(namespace = "accounts")]
-pub async fn optional_float_arg(value: Option<f64>) -> Result<bool, String> {
-  if value.is_some() {
-    Ok(true)
-  } else {
-    Ok(false)
-  }
+pub async fn optional_float_arg(value: Option<f64>) -> Result<Option<f64>, String> {
+  Ok(value)
 }
 
 #[async_dart(namespace = "accounts")]

--- a/example/src/application/advanced.rs
+++ b/example/src/application/advanced.rs
@@ -384,6 +384,24 @@ pub async fn vec_option_float(values: Vec<Option<f64>>) -> Result<Vec<Option<f64
 }
 
 #[async_dart(namespace = "accounts")]
+pub async fn optional_vec_arg(values: Option<Vec<f64>>) -> Result<bool, String> {
+  if values.is_some() {
+    Ok(true)
+  } else {
+    Ok(false)
+  }
+}
+
+#[async_dart(namespace = "accounts")]
+pub async fn optional_float_arg(value: Option<f64>) -> Result<bool, String> {
+  if value.is_some() {
+    Ok(true)
+  } else {
+    Ok(false)
+  }
+}
+
+#[async_dart(namespace = "accounts")]
 pub async fn filter_arg(filter: data::Filter) -> Result<data::Contacts, String> {
   println!("\n[Rust] Received filter: {:?}", filter);
 

--- a/membrane/Cargo.toml
+++ b/membrane/Cargo.toml
@@ -28,8 +28,8 @@ membrane_macro = {version = "0.5", path = "../membrane_macro"}
 membrane_types = {version = "0.3", path = "../membrane_types"}
 regex = "1.5"
 serde = {version = "1.0", features = ["derive"]}
-serde-generate = {git = "https://github.com/jerel/serde-reflection", rev = "04be37b"}
-serde-reflection = {git = "https://github.com/jerel/serde-reflection", rev = "04be37b"}
+serde-generate = "0.24"
+serde-reflection = "0.3"
 
 [dev-dependencies]
 example = {path = "../example", features = ["c-example"]}

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -1034,7 +1034,7 @@ impl Function {
         );
         &de
       }
-      ["Option", _ty] => {
+      ["Option", ..] => {
         panic!(
           "Option is not supported as a bare return type. Return the inner type from {} instead",
           self.fn_name

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -1035,10 +1035,16 @@ impl Function {
         &de
       }
       ["Option", ..] => {
-        panic!(
-          "Option is not supported as a bare return type. Return the inner type from {} instead",
-          self.fn_name
-        )
+        de = format!(
+          "() {{
+            if (deserializer.deserializeOptionTag()) {{
+              return {};
+            }}
+            return null;
+          }}();",
+          self.deserializer(&ty[1..], enum_tracer_registry, config)
+        );
+        &de
       }
       [ty, ..] => {
         de = match enum_tracer_registry.get(ty) {

--- a/membrane_types/src/c.rs
+++ b/membrane_types/src/c.rs
@@ -44,7 +44,7 @@ fn c_type(ty: &[&str], type_: &syn::Type) -> syn::Result<String> {
     ["Option", "i64"] => "const int64_t *",
     ["Option", "f64"] => "const double *",
     ["Option", "bool"] => "const uint8_t *",
-    ["Option", _serialized] => "const uint8_t *",
+    ["Option", ..] => "const uint8_t *",
     _ => {
       return Err(syn::Error::new_spanned(
         type_,

--- a/membrane_types/src/dart.rs
+++ b/membrane_types/src/dart.rs
@@ -103,6 +103,10 @@ pub fn dart_type(types: &[&str]) -> String {
     ["f64"] => "double",
     ["bool"] => "bool",
     ["()"] => "void",
+    ["Option", ..] => {
+      ty = format!("{}?", dart_type(&types[1..]));
+      &ty
+    }
     ["Vec", "Option", ..] => {
       ty = format!("List<{}?>", dart_type(&types[2..]));
       &ty
@@ -270,6 +274,7 @@ fn cast_dart_type_to_c(types: &[&str], variable: &str, ty: &Type) -> syn::Result
       final data = serializer.bytes;
       {ser_partial}
     }}()"#,
+      variable = variable.to_mixed_case(),
       serializer = serializer(types, &variable.to_mixed_case()),
       ser_partial = serialization_partial(),
     ),

--- a/membrane_types/src/rust.rs
+++ b/membrane_types/src/rust.rs
@@ -122,7 +122,7 @@ fn rust_c_type(ty: &[&str], type_: &syn::Type) -> syn::Result<TokenStream2> {
     ["Option", "i64"] => q!(*const ::std::os::raw::c_long),
     ["Option", "f64"] => q!(*const ::std::os::raw::c_double),
     ["Option", "bool"] => q!(*const ::std::os::raw::c_char), // i8
-    ["Option", _serialized] => q!(*const u8),
+    ["Option", ..] => q!(*const u8),
     _ => {
       return Err(syn::Error::new_spanned(
         type_,
@@ -207,7 +207,7 @@ fn cast_c_type_to_rust(types: &[&str], variable: &str, ty: &Type) -> syn::Result
         }
       }
     }
-    ["Option", _serialized] => {
+    ["Option", ..] => {
       let variable_name = variable;
       let variable = Ident::new(variable, Span::call_site());
       let ty = extract_type_from_option(ty).unwrap();


### PR DESCRIPTION
Previously we were accidentally missing test coverage for params of the form `values: Option<Vec<_>>` and in early versions had made a decision to skip support for `-> Result<Option<_>, _>` due to the difficulty of implementation at that time. This PR fixes the first and adds the latter.