### PR TITLE
Ubuntu Linker optimization fix

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -23,3 +23,10 @@ pub fn load() {
   #[cfg(feature = "c-example")]
   application::c_render::load();
 }
+
+// Prevent extern "C" functions from being opitmized out by the linker
+#[used]
+static CANCEL_CALLBACK: unsafe extern "C" fn(*mut membrane::TaskHandle) -> i32 =
+  membrane::membrane_cancel_membrane_task;
+#[used]
+static FREE_VEC: unsafe extern "C" fn(i64, *const u8) -> i32 = membrane::membrane_free_membrane_vec;


### PR DESCRIPTION
-prevents membrane_cancel_membrane_task and
 membrane_free_membrane_vec from being optimized
 out on Ubuntu

Signed-off-by: Joel Winarske <joel.winarske@gmail.com>