### PR TITLE
Add borrowing

### DIFF
--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -5,6 +5,7 @@ import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 import 'package:dart_example/accounts.dart';
 import 'package:dart_example/locations.dart';
+import 'package:dart_example/orgs.dart';
 
 void main() {
   test('can take one item from a stream', () async {
@@ -451,5 +452,14 @@ void main() {
     } on AccountsApiError catch (err) {
       expect(err.e, "The sync rust code panicked");
     }
+  });
+
+  test('test that borrowing from other namespaces works', () async {
+    final accounts = AccountsApi();
+    await accounts.borrowedTypes(id: 10);
+
+    final orgs = OrgsApi();
+    await orgs.getOrgWithBorrowedType(
+        id: Filter(value: [Match(field: "id", value: "1")]));
   });
 }

--- a/example/src/application/advanced.rs
+++ b/example/src/application/advanced.rs
@@ -466,6 +466,15 @@ pub fn slow_stream(sleep_for: i64) -> impl Stream<Item = Result<i32, String>> {
   }
 }
 
+#[async_dart(namespace = "accounts", borrow = "locations::Location")]
+pub async fn borrowed_types(id: i64) -> Result<data::Location, String> {
+  let _id = id;
+
+  Ok(data::Location {
+    polyline_coords: vec![(-104.0185546875, 43.004647127794435)],
+  })
+}
+
 #[async_dart(namespace = "locations")]
 pub async fn get_location(id: i64) -> Result<data::Location, String> {
   let _id = id;
@@ -477,4 +486,34 @@ pub async fn get_location(id: i64) -> Result<data::Location, String> {
       (-94.130859375, 37.85750715625203),
     ],
   })
+}
+
+#[async_dart(
+  namespace = "orgs",
+  borrow = "locations::Location",
+  borrow = "accounts::Contact",
+  borrow = "accounts::Filter",
+  borrow = "accounts::Match",
+  borrow = "accounts::Status"
+)]
+pub async fn get_org_with_borrowed_type(id: data::Filter) -> Result<data::Organization, String> {
+  let _ = id;
+  Ok(data::Organization {
+    id: 1,
+    owner: data::Contact::default(),
+    location: data::Location {
+      polyline_coords: vec![(-104.0185546875, 43.004647127794435)],
+    },
+  })
+}
+
+// this is only to duplicate the above borrows to test import generation, it's never called
+#[async_dart(
+  namespace = "orgs",
+  borrow = "locations::Location",
+  borrow = "accounts::Contact",
+  borrow = "accounts::Contact"
+)]
+pub async fn unused_duplicate_borrows(_id: i64) -> Result<data::Organization, String> {
+  todo!()
 }

--- a/example/src/data.rs
+++ b/example/src/data.rs
@@ -112,3 +112,10 @@ pub struct MoreTypes {
 pub struct Location {
   pub polyline_coords: Vec<(f64, f64)>,
 }
+
+#[derive(Deserialize, Serialize)]
+pub struct Organization {
+  pub id: i64,
+  pub owner: Contact,
+  pub location: Location,
+}

--- a/membrane/src/generators/functions.rs
+++ b/membrane/src/generators/functions.rs
@@ -166,7 +166,7 @@ impl Function {
     "\n  }\n".to_string()
   }
 
-  #[allow(clippy::main_recursion)]
+  #[allow(clippy::only_used_in_recursion)]
   fn deserializer(
     &self,
     ty: &[&str],

--- a/membrane/src/generators/functions.rs
+++ b/membrane/src/generators/functions.rs
@@ -166,7 +166,7 @@ impl Function {
     "\n  }\n".to_string()
   }
 
-  #[allow(clippy::only_used_in_recursion)]
+  #[allow(clippy::main_recursion)]
   fn deserializer(
     &self,
     ty: &[&str],

--- a/membrane/tests/integration_tests.rs
+++ b/membrane/tests/integration_tests.rs
@@ -99,6 +99,18 @@ class Contact {
       "MembraneResponse membrane_accounts_contact(int64_t port, const char *user_id);",
     );
 
+    // verify that borrowed types are no longer created in the borrowing namespace
+    assert!(path.join("lib/src/locations/location.dart").exists() == true);
+    assert!(path.join("lib/src/accounts/contact.dart").exists() == true);
+    assert!(path.join("lib/src/accounts/status.dart").exists() == true);
+    assert!(path.join("lib/src/accounts/filter.dart").exists() == true);
+    assert!(path.join("lib/src/accounts/match.dart").exists() == true);
+    assert!(path.join("lib/src/orgs/location.dart").exists() == false);
+    assert!(path.join("lib/src/orgs/contact.dart").exists() == false);
+    assert!(path.join("lib/src/orgs/status.dart").exists() == false);
+    assert!(path.join("lib/src/orgs/filter.dart").exists() == false);
+    assert!(path.join("lib/src/orgs/match.dart").exists() == false);
+
     build_lib(&path.to_path_buf(), &mut vec![]);
     run_dart(&path.to_path_buf(), vec!["pub", "add", "test"], false);
     run_dart(

--- a/membrane/tests/ui/single.stderr
+++ b/membrane/tests/ui/single.stderr
@@ -6,7 +6,7 @@ error: #[async_dart] expects a `namespace` attribute
    |
    = note: this error originates in the attribute macro `async_dart` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: only `namespace=""`, `disable_logging=true`, `os_thread=true`, and `timeout=1000` are valid options
+error: only `namespace=""`, `borrow="namespace::Type"`, `disable_logging=true`, `os_thread=true`, and `timeout=1000` are valid options
   --> tests/ui/single.rs:27:1
    |
 27 | #[async_dart(namespace = "a", foo = true)]

--- a/membrane_macro/src/lib.rs
+++ b/membrane_macro/src/lib.rs
@@ -466,7 +466,7 @@ pub fn dart_enum(attrs: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 ///
-/// For use inside `#[async_dart]` functions. Used to create an emitter for use with `impl Emitter<result<T, E>>` and `impl StreamEmitter<Result<T, E>>`
+/// For use inside `#[async_dart]` functions. Used to create an emitter for use with `impl Emitter<Result<T, E>>` and `impl StreamEmitter<Result<T, E>>`
 /// return types.
 ///
 /// Example:

--- a/membrane_macro/src/lib.rs
+++ b/membrane_macro/src/lib.rs
@@ -149,6 +149,7 @@ fn to_token_stream(
     disable_logging,
     timeout,
     os_thread,
+    borrow,
   } = options;
 
   let mut functions = TokenStream::new();
@@ -336,6 +337,7 @@ fn to_token_stream(
   } else {
     quote! { None }
   };
+  let borrow = quote! { vec![#(#borrow),*] };
 
   let _deferred_trace = quote! {
       ::membrane::inventory::submit! {
@@ -352,6 +354,7 @@ fn to_token_stream(
                 namespace: #namespace.to_string(),
                 disable_logging: #disable_logging,
                 timeout: #timeout,
+                borrow: #borrow,
                 dart_outer_params: #dart_outer_params.to_string(),
                 dart_transforms: #dart_transforms.to_string(),
                 dart_inner_args: #dart_inner_args.to_string(),
@@ -398,9 +401,16 @@ impl Parse for ReprDartEnum {
   }
 }
 
+///
+/// Apply this macro to enums to mark them for Dart code generation.
+///
+/// Valid options:
+///   * `namespace`, used to select the Dart implementation code directory.
 #[proc_macro_attribute]
 pub fn dart_enum(attrs: TokenStream, input: TokenStream) -> TokenStream {
-  let Options { namespace, .. } = match extract_options(
+  let Options {
+    namespace, borrow, ..
+  } = match extract_options(
     parse_macro_input!(attrs as AttributeArgs),
     Options::default(),
     false,
@@ -416,12 +426,25 @@ pub fn dart_enum(attrs: TokenStream, input: TokenStream) -> TokenStream {
   let mut variants = TokenStream::new();
   variants.extend(input.clone());
 
+  if !borrow.is_empty() {
+    variants.extend::<TokenStream>(
+      syn::Error::new(
+        Span::call_site(),
+        "`borrow` is not a valid option for #[dart_enum]",
+      )
+      .to_compile_error()
+      .into(),
+    );
+  }
+
   let ReprDartEnum { name } = parse_macro_input!(input as ReprDartEnum);
+  let enum_name = name.to_string();
 
   let _deferred_trace = quote! {
       ::membrane::inventory::submit! {
           #![crate = ::membrane]
           ::membrane::DeferredEnumTrace {
+              name: #enum_name.to_string(),
               namespace: #namespace.to_string(),
               trace: |
                 tracer: &mut ::membrane::serde_reflection::Tracer
@@ -443,7 +466,7 @@ pub fn dart_enum(attrs: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 ///
-/// For use inside `#[async_dart]` functions. Used to create an emitter for use with `impl Emitter<Result<T, E>>` and `impl StreamEmitter<Result<T, E>>`
+/// For use inside `#[async_dart]` functions. Used to create an emitter for use with `impl Emitter<result<T, E>>` and `impl StreamEmitter<Result<T, E>>`
 /// return types.
 ///
 /// Example:


### PR DESCRIPTION
This provides the ability to borrow Dart types from another namespace instead of generating a separate copy into each namespace. Example:
```rust
#[async_dart(
  namespace = "orgs",
  borrow = "locations::Location",
  borrow = "accounts::Contact",
  borrow = "accounts::Filter",
  borrow = "accounts::Match",
  borrow = "accounts::Status"
)]
pub async fn get_org_with_borrowed_type(id: data::Filter) -> Result<data::Organization, String> {
  let _ = id;
  Ok(data::Organization {
    id: 1,
    owner: data::Contact::default(),
    location: data::Location {
      polyline_coords: vec![(-104.0185546875, 43.004647127794435)],
    },
  })
}
```
The `borrow` format is `namespace::Class`.