### PR TITLE
Upgrade serde-generate to support Dart enum getters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
 [[package]]
 name = "serde-generate"
 version = "0.24.0"
-source = "git+https://github.com/jerel/serde-reflection?rev=c588f7d#c588f7df685ae52b0a4e6b8efc10e578766d7ac1"
+source = "git+https://github.com/jerel/serde-reflection?rev=cd66898#cd66898c1ec22ca3f68d11f4e8ca86a361ae91fc"
 dependencies = [
  "bcs",
  "bincode",
@@ -875,7 +875,7 @@ dependencies = [
 [[package]]
 name = "serde-reflection"
 version = "0.3.6"
-source = "git+https://github.com/jerel/serde-reflection?rev=c588f7d#c588f7df685ae52b0a4e6b8efc10e578766d7ac1"
+source = "git+https://github.com/jerel/serde-reflection?rev=cd66898#cd66898c1ec22ca3f68d11f4e8ca86a361ae91fc"
 dependencies = [
  "once_cell",
  "serde",

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -779,7 +779,7 @@ dependencies = [
 [[package]]
 name = "serde-generate"
 version = "0.24.0"
-source = "git+https://github.com/jerel/serde-reflection?rev=c588f7d#c588f7df685ae52b0a4e6b8efc10e578766d7ac1"
+source = "git+https://github.com/jerel/serde-reflection?rev=cd66898#cd66898c1ec22ca3f68d11f4e8ca86a361ae91fc"
 dependencies = [
  "bcs",
  "bincode",
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "serde-reflection"
 version = "0.3.6"
-source = "git+https://github.com/jerel/serde-reflection?rev=c588f7d#c588f7df685ae52b0a4e6b8efc10e578766d7ac1"
+source = "git+https://github.com/jerel/serde-reflection?rev=cd66898#cd66898c1ec22ca3f68d11f4e8ca86a361ae91fc"
 dependencies = [
  "once_cell",
  "serde",

--- a/membrane/Cargo.toml
+++ b/membrane/Cargo.toml
@@ -28,8 +28,8 @@ membrane_macro = {version = "0.5", path = "../membrane_macro"}
 membrane_types = {version = "0.3", path = "../membrane_types"}
 regex = "1.5"
 serde = {version = "1.0", features = ["derive"]}
-serde-generate = {git = "https://github.com/jerel/serde-reflection", rev = "c588f7d"}
-serde-reflection = {git = "https://github.com/jerel/serde-reflection", rev = "c588f7d"}
+serde-generate = {git = "https://github.com/jerel/serde-reflection", rev = "cd66898"}
+serde-reflection = {git = "https://github.com/jerel/serde-reflection", rev = "cd66898"}
 
 [dev-dependencies]
 example = {path = "../example", features = ["c-example"]}


### PR DESCRIPTION
This upgrade adds a copyWith implementation (which handles null) like so:
```dart
  Contact copyWith({
    int? id,
    String? fullName,
    Status? status,
  }) {
    return Contact(
      id: id ?? this.id,
      fullName: fullName ?? this.fullName,
      status: status ?? this.status,
    );
  }
```
along with adding getters in the base class for common fields of data enums.