### PR TITLE
Fix mismatched type error on aarch64

### DIFF
--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -98,6 +98,7 @@ use std::{
   collections::{BTreeMap, BTreeSet, HashMap},
   fs::{read_to_string, remove_file},
   io::Write,
+  os::raw::c_char,
   path::{Path, PathBuf},
   process::exit,
 };
@@ -1088,7 +1089,7 @@ pub unsafe extern "C" fn membrane_free_membrane_vec(len: i64, ptr: *const u8) ->
 
 #[doc(hidden)]
 #[no_mangle]
-pub unsafe extern "C" fn membrane_free_membrane_string(ptr: *mut i8) -> i32 {
+pub unsafe extern "C" fn membrane_free_membrane_string(ptr: *mut c_char) -> i32 {
   // turn the pointer back into a CString and Rust will drop it
   let _ = ::std::ffi::CString::from_raw(ptr);
 

--- a/membrane_macro/src/utils.rs
+++ b/membrane_macro/src/utils.rs
@@ -51,7 +51,7 @@ pub(crate) fn maybe_inject_metadata(mut token_stream: TokenStream) -> TokenStrea
             }
 
             #[no_mangle]
-            pub extern "C" fn membrane_metadata_version() -> *mut i8 {
+            pub extern "C" fn membrane_metadata_version() -> *mut std::os::raw::c_char {
               // allow the developer to override the embedded version string with one of their own choosing
               const LIB_VERSION: Option<&str> = option_env!("MEMBRANE_CDYLIB_VERSION");
 
@@ -68,7 +68,7 @@ pub(crate) fn maybe_inject_metadata(mut token_stream: TokenStream) -> TokenStrea
             }
 
             #[no_mangle]
-            pub extern "C" fn membrane_metadata_membrane_version() -> *mut i8 {
+            pub extern "C" fn membrane_metadata_membrane_version() -> *mut std::os::raw::c_char {
               let version = ::std::ffi::CString::new(::membrane::metadata::version()).expect("Invalid string received");
               version.into_raw()
             }


### PR DESCRIPTION
This fixes that type error occurs when build on aarch64.

It is caused from c compiler difference between x86 and aarch64. When aarch64, `char` is `unsigned int`.

https://developer.arm.com/documentation/den0013/d/Porting/Miscellaneous-C-porting-issues/unsigned-char-and-signed-char

```
error[E0308]: mismatched types
    --> /home/.../membrane/src/lib.rs:1087:41
     |
1087 |   let _ = ::std::ffi::CString::from_raw(ptr);
     |                                         ^^^ expected `u8`, found `i8`
     |
     = note: expected raw pointer `*mut u8`
                found raw pointer `*mut i8`
```