### PR TITLE
Add borrow checking and improve the error messaging

### DIFF
--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -239,7 +239,7 @@ impl<'a> Membrane {
           ) {
             Ok(symbols) => symbols,
             Err(msg) => {
-              errors.push(format!("{}", msg));
+              errors.push(msg);
               // panic to terminate without having a compatible branch type
               panic!();
             }
@@ -776,7 +776,7 @@ headers:
     let mut buffer =
       std::fs::File::create(path.clone()).expect("header could not be written at namespace path");
 
-    if let Err(_) = buffer.write_all(head.as_bytes()) {
+    if buffer.write_all(head.as_bytes()).is_err() {
       self.errors.push(format!(
         "unable to write C header file {}",
         path.to_str().unwrap()
@@ -1100,7 +1100,7 @@ class {class_name}Api {{
     let mut reborrows: Vec<String> = non_owned_types
       .iter()
       .filter(|path| owned_types.contains(path))
-      .map(|p| p.clone())
+      .cloned()
       .collect();
 
     reborrows.sort();

--- a/membrane/tests/codegen_reborrow_test.rs
+++ b/membrane/tests/codegen_reborrow_test.rs
@@ -1,0 +1,51 @@
+mod mock;
+use crate::mock::RUNTIME;
+
+mod test {
+  use membrane::Membrane;
+  use pretty_assertions::assert_eq;
+  use std::path::Path;
+
+  #[test]
+  fn test_borrow_errors() {
+    mod app {
+      use membrane::async_dart;
+
+      mod data {
+        #[derive(serde::Deserialize, serde::Serialize)]
+        pub struct Location(pub String);
+      }
+
+      #[async_dart(
+        namespace = "a",
+        // circular reference
+        borrow = "b::Location",
+      )]
+      pub async fn reborrow_one() -> Result<data::Location, String> {
+        todo!()
+      }
+
+      #[async_dart(
+        namespace = "b",
+        // circular reference
+        borrow = "a::Location",
+      )]
+      pub async fn reborrow_two() -> Result<data::Location, String> {
+        todo!()
+      }
+    }
+
+    // gather metadata types and ensure that the above circular dependency is caught
+    let mut membrane = Membrane::new();
+
+    membrane
+      .package_destination_dir(Path::new("../dart_example"))
+      .create_pub_package()
+      .write_api();
+
+    assert_eq!(
+      membrane.drain_errors(),
+      vec!["The following `borrows` were found which attempt to reborrow a type which is not owned by the target namespace: `a::Location, b::Location`"]
+    );
+  }
+}

--- a/membrane/tests/codegen_self_borrow_test.rs
+++ b/membrane/tests/codegen_self_borrow_test.rs
@@ -1,0 +1,42 @@
+mod mock;
+use crate::mock::RUNTIME;
+
+mod test {
+  use membrane::Membrane;
+  use pretty_assertions::assert_eq;
+  use std::path::Path;
+
+  #[test]
+  fn test_self_borrow_errors() {
+    mod app {
+      use membrane::async_dart;
+
+      mod data {
+        #[derive(serde::Deserialize, serde::Serialize)]
+        pub struct Location(pub String);
+      }
+
+      #[async_dart(
+        namespace = "a",
+        // self reference
+        borrow = "a::Location",
+      )]
+      pub async fn borrow_one() -> Result<data::Location, String> {
+        todo!()
+      }
+    }
+
+    // gather metadata types and ensure that the above self reference is caught
+    let mut membrane = Membrane::new();
+
+    membrane
+      .package_destination_dir(Path::new("../dart_example"))
+      .create_pub_package()
+      .write_api();
+
+    assert_eq!(
+      membrane.drain_errors(),
+      vec!["`a::Location` was borrowed by `a` which is a self reference"]
+    );
+  }
+}

--- a/membrane/tests/integration_tests.rs
+++ b/membrane/tests/integration_tests.rs
@@ -2,7 +2,7 @@ mod test_utils;
 
 mod test {
   use super::test_utils::*;
-  
+
   use membrane::Membrane;
   use serial_test::serial;
   use std::{fs::read_to_string, path::Path};

--- a/membrane/tests/integration_tests.rs
+++ b/membrane/tests/integration_tests.rs
@@ -2,7 +2,7 @@ mod test_utils;
 
 mod test {
   use super::test_utils::*;
-  use example;
+  
   use membrane::Membrane;
   use serial_test::serial;
   use std::{fs::read_to_string, path::Path};
@@ -45,7 +45,7 @@ mod test {
     let path = Path::new("../dart_example");
 
     // reference the example lib so it doesn't get optimized away
-    let _ = example::load();
+    example::load();
 
     Membrane::new()
       .timeout(200)
@@ -100,18 +100,18 @@ class Contact {
     );
 
     // verify that borrowed types are no longer created in the borrowing namespace
-    assert!(path.join("lib/src/locations/location.dart").exists() == true);
-    assert!(path.join("lib/src/accounts/contact.dart").exists() == true);
-    assert!(path.join("lib/src/accounts/status.dart").exists() == true);
-    assert!(path.join("lib/src/accounts/filter.dart").exists() == true);
-    assert!(path.join("lib/src/accounts/match.dart").exists() == true);
-    assert!(path.join("lib/src/common/shared_type.dart").exists() == true);
-    assert!(path.join("lib/src/orgs/location.dart").exists() == false);
-    assert!(path.join("lib/src/orgs/contact.dart").exists() == false);
-    assert!(path.join("lib/src/orgs/status.dart").exists() == false);
-    assert!(path.join("lib/src/orgs/filter.dart").exists() == false);
-    assert!(path.join("lib/src/orgs/match.dart").exists() == false);
-    assert!(path.join("lib/src/orgs/shared_type.dart").exists() == false);
+    assert!(path.join("lib/src/locations/location.dart").exists());
+    assert!(path.join("lib/src/accounts/contact.dart").exists());
+    assert!(path.join("lib/src/accounts/status.dart").exists());
+    assert!(path.join("lib/src/accounts/filter.dart").exists());
+    assert!(path.join("lib/src/accounts/match.dart").exists());
+    assert!(path.join("lib/src/common/shared_type.dart").exists());
+    assert!(!path.join("lib/src/orgs/location.dart").exists());
+    assert!(!path.join("lib/src/orgs/contact.dart").exists());
+    assert!(!path.join("lib/src/orgs/status.dart").exists());
+    assert!(!path.join("lib/src/orgs/filter.dart").exists());
+    assert!(!path.join("lib/src/orgs/match.dart").exists());
+    assert!(!path.join("lib/src/orgs/shared_type.dart").exists());
 
     let imports =
       read_to_string(path.join("lib").join("src").join("orgs").join("orgs.dart")).unwrap();
@@ -139,7 +139,7 @@ import '../locations/locations.dart' show Location;
     let path = Path::new("../dart_example");
 
     // reference the example lib so it doesn't get optimized away
-    let _ = example::load();
+    example::load();
 
     Membrane::new()
       .with_c_style_enums(false)

--- a/membrane/tests/mock.rs
+++ b/membrane/tests/mock.rs
@@ -1,0 +1,28 @@
+use membrane::runtime::{App, Interface, JoinHandle};
+use std::future::Future;
+
+pub struct TestRuntime();
+
+impl Interface for TestRuntime {
+  fn spawn<T>(&self, _future: T) -> JoinHandle
+  where
+    T: Future + Send + 'static,
+    T::Output: Send + 'static,
+  {
+    JoinHandle {
+      abort: Box::new(|| {}),
+    }
+  }
+
+  fn spawn_blocking<F, R>(&self, _future: F) -> JoinHandle
+  where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+  {
+    JoinHandle {
+      abort: Box::new(|| {}),
+    }
+  }
+}
+
+pub static RUNTIME: App<TestRuntime> = App::new(|| TestRuntime());

--- a/membrane/tests/mock.rs
+++ b/membrane/tests/mock.rs
@@ -25,4 +25,4 @@ impl Interface for TestRuntime {
   }
 }
 
-pub static RUNTIME: App<TestRuntime> = App::new(|| TestRuntime());
+pub static RUNTIME: App<TestRuntime> = App::new(TestRuntime);

--- a/membrane/tests/test_utils.rs
+++ b/membrane/tests/test_utils.rs
@@ -49,9 +49,9 @@ pub fn build_lib(path: &PathBuf, additional_args: &mut Vec<&str>) {
 
 pub fn run_dart(path: &PathBuf, args: Vec<&str>, verbose: bool) {
   let pub_get = Command::new("dart")
-      .current_dir(&path)
+      .current_dir(path)
       // set the library path to our temp pub project for linux
-      .env("LD_LIBRARY_PATH", &path)
+      .env("LD_LIBRARY_PATH", path)
       .arg("--disable-analytics")
       .args(args)
       .output()


### PR DESCRIPTION
This prevents a developer from accidentally borrowing a type from their own namespace or having a circular relationship between borrows.