### PR TITLE
Support functions that return `impl Future`

### DIFF
--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -35,6 +35,11 @@ void main() {
             Contact(id: 1, fullName: "Alice Smith", status: Status.pending)));
   });
 
+  test('can get a value from a function that returns impl Future', () async {
+    final accounts = AccountsApi();
+    expect(await accounts.implFuture(), 42);
+  });
+
   test('can call os-threaded Rust and get contact', () async {
     final accounts = AccountsApi();
     expect(

--- a/example/src/application/advanced.rs
+++ b/example/src/application/advanced.rs
@@ -173,6 +173,11 @@ pub async fn options_demo(
   })
 }
 
+#[async_dart(namespace = "accounts")]
+pub fn impl_future() -> impl futures::Future<Output = Result<i64, String>> {
+  async { Ok(42) }
+}
+
 #[async_dart(namespace = "accounts", disable_logging = true)]
 pub async fn scalar_empty() -> Result<(), String> {
   Ok(())

--- a/membrane_macro/src/parsers.rs
+++ b/membrane_macro/src/parsers.rs
@@ -15,6 +15,17 @@ pub fn parse_trait_return_type(input: ParseStream) -> Result<(OutputStyle, syn::
   input.parse::<Token![<]>()?;
 
   match stream_ident.to_string().as_str() {
+    "Future" => {
+      let item_ident = input.parse::<Ident>()?;
+      if item_ident != "Output" {
+        return Err(Error::new(span, "expected `impl Future<Output = Result>`"));
+      }
+
+      input.parse::<Token![=]>()?;
+      let (t, e) = parse_type(input)?;
+      input.parse::<Token![>]>()?;
+      Ok((OutputStyle::Serialized, t, e))
+    }
     "Stream" => {
       let item_ident = input.parse::<Ident>()?;
       if item_ident != "Item" {


### PR DESCRIPTION
```rust
#[async_dart(namespace = "accounts")]
pub fn future_example() -> impl futures::Future<Output = Result<i64, String>> {
  async { Ok(42) }
}
```