### PR TITLE
Release 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,17 +57,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,15 +135,36 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -344,15 +354,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -361,13 +362,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "1.3.0"
+name = "hermit-abi"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "include_dir"
@@ -404,6 +408,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,9 +444,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libloading"
@@ -430,6 +457,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -452,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "membrane"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "allo-isolate",
  "bincode",
@@ -478,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "membrane_macro"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "membrane_types",
  "once_cell",
@@ -525,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "output_vt100"
@@ -637,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "pretty_env_logger"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
 dependencies = [
  "env_logger",
  "log",
@@ -659,12 +692,6 @@ checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -730,6 +757,20 @@ name = "regex-syntax"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+
+[[package]]
+name = "rustix"
+version = "0.37.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "ryu"

--- a/membrane/Cargo.toml
+++ b/membrane/Cargo.toml
@@ -8,7 +8,7 @@ name = "membrane"
 readme = "../README.md"
 repository = "https://github.com/jerel/membrane"
 rust-version = "1.61"
-version = "0.7.0"
+version = "0.8.0"
 
 [lib]
 crate-type = ["lib"]
@@ -27,10 +27,10 @@ futures = {version = "0.3", features = ["executor"]}
 git-version = "0.3"
 inventory = "0.2"
 libloading = "0.8"
-membrane_macro = {version = "0.6", path = "../membrane_macro"}
+membrane_macro = {version = "0.7", path = "../membrane_macro"}
 membrane_types = {version = "0.4", path = "../membrane_types"}
-once_cell = "1.17"
-pretty_env_logger = "0.4"
+once_cell = "1.18"
+pretty_env_logger = "0.5"
 regex = "1.8"
 serde = {version = "1.0", features = ["derive"]}
 serde-generate = {version = "0.25", features = ["dart"]}
@@ -39,6 +39,6 @@ tracing = {version = "0.1", features = ["log"]}
 
 [dev-dependencies]
 example = {path = "../example", features = ["c-example"]}
-pretty_assertions = "1.2"
+pretty_assertions = "1.3"
 serial_test = "2.0"
 trybuild = "1.0"

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -462,8 +462,14 @@ impl<'a> Membrane {
       let registry = match self.namespaced_registry.get(namespace).unwrap() {
         Ok(reg) => reg,
         Err(Error::MissingVariants(names)) => {
-          self.errors.push(format!(
-            "An enum was used that has not had the membrane::dart_enum macro applied for the consuming namespace. Please add #[dart_enum(namespace = \"{}\")] to the {} enum.",
+          self.errors.push(format!(r#"
+##
+#
+# An enum was used that has not had the membrane::dart_enum macro applied for a namespace which owns or borrows it.
+#
+# Please add #[dart_enum(namespace = "{}")] to the {} enum.
+#
+##"#,
             namespace,
             names.first().unwrap()
           ));
@@ -1118,7 +1124,7 @@ impl Drop for Membrane {
   fn drop(&mut self) {
     if self.is_err() {
       for err in self.errors.iter() {
-        tracing::error!("{:?}", err);
+        tracing::error!("{}", err);
       }
       exit(1);
     }

--- a/membrane/src/runtime.rs
+++ b/membrane/src/runtime.rs
@@ -7,10 +7,26 @@ pub trait Interface {
     F: Future + Send + 'static,
     F::Output: Send + 'static;
 
+  fn info_spawn<F>(&self, future: F, _info: Info) -> JoinHandle
+  where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+  {
+    self.spawn(future)
+  }
+
   fn spawn_blocking<F, R>(&self, future: F) -> JoinHandle
   where
     F: FnOnce() -> R + Send + 'static,
     R: Send + 'static;
+
+  fn info_spawn_blocking<F, R>(&self, future: F, _info: Info) -> JoinHandle
+  where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+  {
+    self.spawn_blocking(future)
+  }
 }
 
 pub struct JoinHandle {
@@ -21,6 +37,10 @@ impl JoinHandle {
   pub fn abort(&self) {
     (self.abort)();
   }
+}
+
+pub struct Info<'a> {
+  pub name: &'a str,
 }
 
 #[derive(Debug)]

--- a/membrane_macro/Cargo.toml
+++ b/membrane_macro/Cargo.toml
@@ -4,7 +4,7 @@ description = "A companion crate for `membrane`"
 edition = "2018"
 license = "Apache-2.0"
 name = "membrane_macro"
-version = "0.6.0"
+version = "0.7.0"
 
 [lib]
 proc-macro = true
@@ -17,5 +17,5 @@ skip-generate = []
 
 [dependencies]
 membrane_types = {version = "0.4", path = "../membrane_types"}
-once_cell = "1.17"
+once_cell = "1.18"
 toml = "0.5"


### PR DESCRIPTION
* Adds an `info_*` version of the runtime trait `spawn_*` methods that allow an end-user to conditionally override and get debug info. For example to use with the experimental tokio task Builder that allows naming tasks.
* Upgrades dependencies
* Improves the "missing dart_enum" prompt to make it more informative