### PR TITLE
Correctly handle casing for borrowing non-standard type names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,7 +479,7 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "membrane"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "allo-isolate",
  "bincode",

--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -387,7 +387,8 @@ void main() {
   test('can fetch a vector from a separate namespace', () async {
     final locations = LocationsApi();
     expect(
-        (await locations.getLocation(id: 10)).polylineCoords,
+        (await locations.getLocation(id: 10, withinGdpr: GDPR(value: true)))
+            .polylineCoords,
         equals([
           [-104.0185546875, 43.004647127794435],
           [-104.0625, 37.78808138412046],
@@ -403,7 +404,7 @@ void main() {
     });
 
     final locations = LocationsApi();
-    await locations.getLocation(id: 1);
+    await locations.getLocation(id: 1, withinGdpr: GDPR(value: true));
 
     expect(logs.first, contains('[FINE] membrane.locations:'));
   });
@@ -494,6 +495,7 @@ void main() {
 
     final orgs = OrgsApi();
     await orgs.getOrgWithBorrowedType(
-        id: Filter(value: [Match(field: "id", value: "1")]));
+        id: Filter(value: [Match(field: "id", value: "1")]),
+        withinGdpr: GDPR(value: true));
   });
 }

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -423,7 +423,7 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "membrane"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "allo-isolate",
  "bincode",

--- a/example/src/application/advanced.rs
+++ b/example/src/application/advanced.rs
@@ -535,7 +535,7 @@ pub async fn borrowed_types(id: i64) -> Result<data::Location, String> {
 }
 
 #[async_dart(namespace = "locations")]
-pub async fn get_location(id: i64) -> Result<data::Location, String> {
+pub async fn get_location(id: i64, _within_gdpr: data::GDPR) -> Result<data::Location, String> {
   let _id = id;
 
   Ok(data::Location {
@@ -549,11 +549,15 @@ pub async fn get_location(id: i64) -> Result<data::Location, String> {
 
 #[async_dart(
   namespace = "orgs",
+  borrow = "locations::GDPR",
   borrow = "locations::Location",
   borrow = "accounts::Contact",
   borrow = "accounts::Filter"
 )]
-pub async fn get_org_with_borrowed_type(id: data::Filter) -> Result<data::Organization, String> {
+pub async fn get_org_with_borrowed_type(
+  id: data::Filter,
+  _within_gdpr: data::GDPR,
+) -> Result<data::Organization, String> {
   let _ = id;
   Ok(data::Organization {
     id: 1,

--- a/example/src/data.rs
+++ b/example/src/data.rs
@@ -137,3 +137,7 @@ pub struct Organization {
   pub owner: Contact,
   pub location: Location,
 }
+
+// test the borrowing of types which are cased differently in Dart and Rust
+#[derive(Deserialize, Serialize)]
+pub struct GDPR(pub bool);

--- a/membrane/Cargo.toml
+++ b/membrane/Cargo.toml
@@ -8,7 +8,7 @@ name = "membrane"
 readme = "../README.md"
 repository = "https://github.com/jerel/membrane"
 rust-version = "1.61"
-version = "0.9.3"
+version = "0.9.4"
 
 [lib]
 crate-type = ["lib"]

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -1092,11 +1092,12 @@ class {class_name}Api {{
             .unwrap()
             .lines()
             .filter_map(|line| {
-              if borrowed_types.contains(
+              // because CamelCasing the snake_cased `part 'central_usa.dart'` won't match the
+              // acronym borrow `CentralUSA` we instead convert the borrows to snake_case to do the match
+              if borrowed_types.iter().map(|t| t.to_snake_case()).collect::<Vec<String>>().contains(
                 &line
                   .replace("part '", "")
                   .replace(".dart';", "")
-                  .to_upper_camel_case(),
               ) {
                 None
               } else if line.starts_with("import '../bincode") {

--- a/membrane/tests/integration_tests.rs
+++ b/membrane/tests/integration_tests.rs
@@ -120,7 +120,7 @@ class Contact {
       &imports,
       "import '../accounts/accounts.dart' show Contact, Filter, Match, Reports, Status, StatusExtension;
 import '../common/common.dart' show Arg, Error, Mixed, SharedType, VecWrapper;
-import '../locations/locations.dart' show Location;
+import '../locations/locations.dart' show GDPR, Location;
 ",
     );
 


### PR DESCRIPTION
For example: `borrow = "example::USA"` was incorrectly handled as the case would be converted to `Usa` resulting in a `part 'usa.dart';` being left in the borrowing namespace's library file.