### PR TITLE
Release 0.9.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,7 +479,7 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "membrane"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "allo-isolate",
  "bincode",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "membrane_macro"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "membrane_types",
  "once_cell",

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -423,7 +423,7 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "membrane"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "allo-isolate",
  "bincode",
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "membrane_macro"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "membrane_types",
  "once_cell",

--- a/membrane/Cargo.toml
+++ b/membrane/Cargo.toml
@@ -8,7 +8,7 @@ name = "membrane"
 readme = "../README.md"
 repository = "https://github.com/jerel/membrane"
 rust-version = "1.61"
-version = "0.9.5"
+version = "0.9.6"
 
 [lib]
 crate-type = ["lib"]

--- a/membrane_macro/Cargo.toml
+++ b/membrane_macro/Cargo.toml
@@ -4,7 +4,7 @@ description = "A companion crate for `membrane`"
 edition = "2018"
 license = "Apache-2.0"
 name = "membrane_macro"
-version = "0.7.0"
+version = "0.7.1"
 
 [lib]
 proc-macro = true

--- a/membrane_macro/src/parsers.rs
+++ b/membrane_macro/src/parsers.rs
@@ -61,6 +61,8 @@ pub fn parse_return_type(input: ParseStream) -> Result<(OutputStyle, syn::Type, 
 fn parse_type(input: ParseStream) -> Result<(syn::Type, syn::Type)> {
   let outer_span = input.span();
   let type_path = input.parse::<syn::TypePath>()?;
+  // if the formatter inserts a trailing comma on multi-line types then discard it
+  let _ = input.parse::<Token![,]>();
   let return_type = &type_path.path.segments.last().unwrap();
   if return_type.ident != "Result" {
     return Err(Error::new(outer_span, "expected enum `Result`"));

--- a/membrane_types/src/rust.rs
+++ b/membrane_types/src/rust.rs
@@ -113,13 +113,13 @@ pub fn flatten_types(ty: &syn::Type, mut types: Vec<String>) -> syn::Result<Vec<
 fn rust_c_type(ty: &[&str], type_: &syn::Type) -> syn::Result<TokenStream2> {
   let result = match ty[..] {
     ["String"] => q!(*const ::std::os::raw::c_char),
-    ["i64"] => q!(::std::os::raw::c_long),
+    ["i64"] => q!(::std::os::raw::c_longlong),
     ["f64"] => q!(::std::os::raw::c_double),
     ["bool"] => q!(::std::os::raw::c_char), // i8
     ["Vec", ..] => q!(*const u8),
     [serialized] if serialized != "Option" => q!(*const u8),
     ["Option", "String"] => q!(*const ::std::os::raw::c_char),
-    ["Option", "i64"] => q!(*const ::std::os::raw::c_long),
+    ["Option", "i64"] => q!(*const ::std::os::raw::c_longlong),
     ["Option", "f64"] => q!(*const ::std::os::raw::c_double),
     ["Option", "bool"] => q!(*const ::std::os::raw::c_char), // i8
     ["Option", ..] => q!(*const u8),


### PR DESCRIPTION
Fixes two bugs:
* On really long type names the formatter can break a function return's `impl Stream<Item = Result<Foo, Bar>,>` into two lines with a trailing comma. Our macro parser didn't expect that and would complain about finding a comma instead of `>`.
* Compiling on Windows toolchains would complain about `c_long` for `i64` because Windows might only use 32 bits for `c_long`.