### PR TITLE
Include the location of macro usage when emitting borrow errors

### DIFF
--- a/dart_example/test/main_test.dart
+++ b/dart_example/test/main_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:logging/logging.dart';
@@ -469,7 +470,9 @@ void main() {
       expect(err.duration?.inMilliseconds, 200);
       expect(err.message, "Future not completed");
     }
-  });
+  },
+      // temporarily skipped in CI due to https://github.com/rust-lang/rust/issues/88622
+      skip: Platform.environment['CI'] == 'true');
 
   test(
       'test that panics in stream code are handled gracefully and merely time out',
@@ -481,13 +484,17 @@ void main() {
       expect(err.duration?.inMilliseconds, 20);
       expect(err.message, "No stream event");
     }
-  });
+  },
+      // temporarily skipped in CI due to https://github.com/rust-lang/rust/issues/88622
+      skip: Platform.environment['CI'] == 'true');
 
   test('test that panics in sync code are handled gracefully', () {
     final accounts = AccountsApi();
     expect(() async => accounts.contactSyncPanic(),
         throwsA(isA<MembraneException>()));
-  });
+  },
+      // temporarily skipped in CI due to https://github.com/rust-lang/rust/issues/88622
+      skip: Platform.environment['CI'] == 'true');
 
   test('test that borrowing from other namespaces works', () async {
     final accounts = AccountsApi();

--- a/membrane/src/generators/functions.rs
+++ b/membrane/src/generators/functions.rs
@@ -315,7 +315,7 @@ impl Callable for Ffi {
       } else {
         String::from(", ") + self.fun.dart_inner_args
       },
-      fine_logger = config.dart_config.fine_log_fn
+      fine_logger = config.dart_config.logger.fine_log_fn
     )
     .as_str();
     self
@@ -350,7 +350,7 @@ impl Callable for Ffi {
         error_de = self.fun.deserializer(self.fun.error_type, enum_tracer_registry, config),
         class_name = self.fun.namespace.to_upper_camel_case(),
         fn_name = self.fun.fn_name,
-        fine_logger = config.dart_config.fine_log_fn
+        fine_logger = config.dart_config.logger.fine_log_fn
       )
     } else if self.fun.is_stream {
       format!(
@@ -383,7 +383,7 @@ impl Callable for Ffi {
           // having all streams auto-disconnect after a pause in events is not desirable
           "".to_string()
         },
-        fine_logger = config.dart_config.fine_log_fn
+        fine_logger = config.dart_config.logger.fine_log_fn
       )
     } else {
       format!(
@@ -422,7 +422,7 @@ impl Callable for Ffi {
           // and by default we won't time out at all
           "".to_string()
         },
-        fine_logger = config.dart_config.fine_log_fn
+        fine_logger = config.dart_config.logger.fine_log_fn
       )
     }
     .as_str();

--- a/membrane/src/generators/functions.rs
+++ b/membrane/src/generators/functions.rs
@@ -58,7 +58,7 @@ impl Builder for Ffi {
       output: self
         .begin()
         .signature()
-        .body()
+        .body(config)
         .body_return(enum_registry, config)
         .end()
         .output
@@ -80,9 +80,9 @@ impl Builder for Web {
     self.output.as_bytes()
   }
 
-  fn build(&mut self, _config: &Membrane) -> Web {
+  fn build(&mut self, config: &Membrane) -> Web {
     Web {
-      output: self.begin().signature().body().end().output.clone(),
+      output: self.begin().signature().body(config).end().output.clone(),
       fun: self.fun.clone(),
     }
   }
@@ -246,7 +246,7 @@ impl Function {
 trait Callable {
   fn begin(&mut self) -> &mut Self;
   fn signature(&mut self) -> &mut Self;
-  fn body(&mut self) -> &mut Self;
+  fn body(&mut self, config: &Membrane) -> &mut Self;
   fn body_return(&mut self, enum_tracer_registry: &Registry, config: &Membrane) -> &mut Self;
   fn end(&mut self) -> &mut Self;
 }
@@ -262,7 +262,7 @@ impl Callable for Ffi {
     self
   }
 
-  fn body(&mut self) -> &mut Self {
+  fn body(&mut self, config: &Membrane) -> &mut Self {
     self.output += format!(
       r#" {{{disable_logging}
     final List<Pointer> _toFree = [];{fn_transforms}{receive_port}
@@ -270,7 +270,7 @@ impl Callable for Ffi {
     MembraneResponse _taskResult;
     try {{
       if (!_loggingDisabled) {{
-        _log.fine('Calling Rust `{fn_name}` via C `{extern_c_fn_name}`');
+        _log.{fine_logger}('Calling Rust `{fn_name}` via C `{extern_c_fn_name}`');
       }}
       _taskResult = _bindings.{extern_c_fn_name}({native_port}{dart_inner_args});
       if (_taskResult.kind == MembraneResponseKind.panic) {{
@@ -282,7 +282,7 @@ impl Callable for Ffi {
     }} finally {{
       _toFree.forEach((ptr) => calloc.free(ptr));
       if (!_loggingDisabled) {{
-        _log.fine('Freed arguments to `{extern_c_fn_name}`');
+        _log.{fine_logger}('Freed arguments to `{extern_c_fn_name}`');
       }}
     }}
 "#,
@@ -315,6 +315,7 @@ impl Callable for Ffi {
       } else {
         String::from(", ") + self.fun.dart_inner_args
       },
+      fine_logger = config.dart_config.fine_log_fn
     )
     .as_str();
     self
@@ -333,7 +334,7 @@ impl Callable for Ffi {
     final length = ByteData.view(data.asTypedList(8).buffer).getInt64(0, Endian.little);
     try {{
       if (!_loggingDisabled) {{
-        _log.fine('Deserializing data from {fn_name}');
+        _log.{fine_logger}('Deserializing data from {fn_name}');
       }}
       final deserializer = BincodeDeserializer(data.asTypedList(length + 8).sublist(8));
       if (deserializer.deserializeUint8() == MembraneMsgKind.ok) {{
@@ -349,6 +350,7 @@ impl Callable for Ffi {
         error_de = self.fun.deserializer(self.fun.error_type, enum_tracer_registry, config),
         class_name = self.fun.namespace.to_upper_camel_case(),
         fn_name = self.fun.fn_name,
+        fine_logger = config.dart_config.fine_log_fn
       )
     } else if self.fun.is_stream {
       format!(
@@ -356,7 +358,7 @@ impl Callable for Ffi {
     try {{
       yield* _port{timeout}.map((input) {{
         if (!_loggingDisabled) {{
-          _log.fine('Deserializing data from {fn_name}');
+          _log.{fine_logger}('Deserializing data from {fn_name}');
         }}
         final deserializer = BincodeDeserializer(input as Uint8List);
         if (deserializer.deserializeUint8() == MembraneMsgKind.ok) {{
@@ -381,13 +383,14 @@ impl Callable for Ffi {
           // having all streams auto-disconnect after a pause in events is not desirable
           "".to_string()
         },
+        fine_logger = config.dart_config.fine_log_fn
       )
     } else {
       format!(
         r#"
     try {{
       if (!_loggingDisabled) {{
-        _log.fine('Deserializing data from {fn_name}');
+        _log.{fine_logger}('Deserializing data from {fn_name}');
       }}
       final deserializer = BincodeDeserializer(await _port.first{timeout} as Uint8List);
       if (deserializer.deserializeUint8() == MembraneMsgKind.ok) {{
@@ -419,6 +422,7 @@ impl Callable for Ffi {
           // and by default we won't time out at all
           "".to_string()
         },
+        fine_logger = config.dart_config.fine_log_fn
       )
     }
     .as_str();
@@ -438,7 +442,7 @@ impl Callable for Web {
     self
   }
 
-  fn body(&mut self) -> &mut Self {
+  fn body(&mut self, _config: &Membrane) -> &mut Self {
     self.output += "{
       throw UnimplementedError();";
 
@@ -478,7 +482,7 @@ impl Callable for C {
     self
   }
 
-  fn body(&mut self) -> &mut Self {
+  fn body(&mut self, _config: &Membrane) -> &mut Self {
     self
   }
 

--- a/membrane/src/generators/loaders.rs
+++ b/membrane/src/generators/loaders.rs
@@ -74,10 +74,10 @@ bool bindingsLoaded = false;
 final bindings = _load();
 "#,
     lib = library,
-    logger_path = dart_config.logger_import_path,
-    logger = dart_config.logger,
-    info_logger = dart_config.info_log_fn,
-    fine_logger = dart_config.fine_log_fn,
+    logger_path = dart_config.logger.import_path,
+    logger = dart_config.logger.instance,
+    info_logger = dart_config.logger.info_log_fn,
+    fine_logger = dart_config.logger.fine_log_fn,
   )
 }
 

--- a/membrane/src/generators/loaders.rs
+++ b/membrane/src/generators/loaders.rs
@@ -50,7 +50,7 @@ _load() {{
     'store_dart_post_cobject',
   );
 
-  {logger}.{debug_logger}('Initializing Dart_PostCObject');
+  {logger}.{fine_logger}('Initializing Dart_PostCObject');
   storeDartPostCobject(NativeApi.postCObject);
 
   final ptr = bindings.membrane_metadata_version();
@@ -77,7 +77,7 @@ final bindings = _load();
     logger_path = dart_config.logger_import_path,
     logger = dart_config.logger,
     info_logger = dart_config.info_log_fn,
-    debug_logger = dart_config.debug_log_fn,
+    fine_logger = dart_config.fine_log_fn,
   )
 }
 

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -107,10 +107,10 @@ use tracing::{debug, info, warn};
 
 #[derive(Debug)]
 pub struct DartConfig {
-  logger_import_path: &'static str,
-  logger: &'static str,
-  info_log_fn: &'static str,
-  debug_log_fn: &'static str,
+  pub logger_import_path: &'static str,
+  pub logger: &'static str,
+  pub info_log_fn: &'static str,
+  pub fine_log_fn: &'static str,
 }
 
 impl Default for DartConfig {
@@ -119,7 +119,7 @@ impl Default for DartConfig {
       logger_import_path: "package:logging/logging.dart",
       logger: "Logger('membrane')",
       info_log_fn: "info",
-      debug_log_fn: "fine",
+      fine_log_fn: "fine",
     }
   }
 }
@@ -570,7 +570,7 @@ impl<'a> Membrane {
   ///   logger_import_path: "package:logging/logging.dart",
   ///   logger: "Logger('membrane')",
   ///   info_log_fn: "info",
-  ///   debug_log_fn: "fine",
+  ///   fine_log_fn: "fine",
   /// }
   pub fn dart_config(&mut self, config: DartConfig) -> &mut Self {
     return_if_error!(self);

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -297,7 +297,7 @@ impl<'a> Membrane {
       )
     });
 
-    let mut namespaces = vec![
+    let mut namespaces = [
       enums.iter().map(|x| x.namespace).collect::<Vec<&str>>(),
       functions.iter().map(|x| x.namespace).collect::<Vec<&str>>(),
     ]

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -572,10 +572,12 @@ impl<'a> Membrane {
   /// Default:
   ///
   /// DartConfig {
-  ///   import_path: "package:logging/logging.dart",
-  ///   logger: "Logger('membrane')",
-  ///   info_log_fn: "info",
-  ///   fine_log_fn: "fine",
+  ///   logger: DartLoggerConfig {
+  ///     import_path: "package:logging/logging.dart",
+  ///     instance: "Logger('membrane')",
+  ///     info_log_fn: "info",
+  ///     fine_log_fn: "fine",
+  ///   }
   /// }
   pub fn dart_config(&mut self, config: DartConfig) -> &mut Self {
     return_if_error!(self);

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -105,19 +105,24 @@ use std::{
 };
 use tracing::{debug, info, warn};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct DartConfig {
-  pub logger_import_path: &'static str,
-  pub logger: &'static str,
+  pub logger: DartLoggerConfig,
+}
+
+#[derive(Debug)]
+pub struct DartLoggerConfig {
+  pub import_path: &'static str,
+  pub instance: &'static str,
   pub info_log_fn: &'static str,
   pub fine_log_fn: &'static str,
 }
 
-impl Default for DartConfig {
+impl Default for DartLoggerConfig {
   fn default() -> Self {
     Self {
-      logger_import_path: "package:logging/logging.dart",
-      logger: "Logger('membrane')",
+      import_path: "package:logging/logging.dart",
+      instance: "Logger('membrane')",
       info_log_fn: "info",
       fine_log_fn: "fine",
     }
@@ -567,7 +572,7 @@ impl<'a> Membrane {
   /// Default:
   ///
   /// DartConfig {
-  ///   logger_import_path: "package:logging/logging.dart",
+  ///   import_path: "package:logging/logging.dart",
   ///   logger: "Logger('membrane')",
   ///   info_log_fn: "info",
   ///   fine_log_fn: "fine",
@@ -978,10 +983,11 @@ class {class_name}Api {{
 "#,
       ns = &namespace,
       class_name = &namespace.to_upper_camel_case(),
-      logger_path = self.dart_config.logger_import_path,
+      logger_path = self.dart_config.logger.import_path,
       logger = self
         .dart_config
         .logger
+        .instance
         .replace("')", &format!(".{}')", &namespace))
         .replace("\")", &format!(".{}\")", &namespace)),
     );

--- a/membrane/src/lib.rs
+++ b/membrane/src/lib.rs
@@ -117,7 +117,7 @@ impl Default for DartConfig {
   fn default() -> Self {
     Self {
       logger_import_path: "package:logging/logging.dart",
-      logger: "Logger(\"membrane\")",
+      logger: "Logger('membrane')",
       info_log_fn: "info",
       debug_log_fn: "fine",
     }
@@ -568,7 +568,7 @@ impl<'a> Membrane {
   ///
   /// DartConfig {
   ///   logger_import_path: "package:logging/logging.dart",
-  ///   logger: "Logger(\"membrane\")",
+  ///   logger: "Logger('membrane')",
   ///   info_log_fn: "info",
   ///   debug_log_fn: "fine",
   /// }

--- a/membrane/src/utils.rs
+++ b/membrane/src/utils.rs
@@ -33,19 +33,19 @@ pub(crate) fn display_code_location(location: Option<&Vec<SourceCodeLocation>>) 
           .map(|(index, path)| {
             if last == 0 {
               // single item
-              format!("{}", path)
+              path.to_string()
             } else if index == 0 && last == 1 {
               // on the first of two
               format!("{} and", path)
             } else if index == 1 && last == 1 {
               // on the second of two
-              format!("{}", path)
+              path.to_string()
             } else if index == (last - 1) {
               // on the next to last of many
               format!("{}, and", path)
             } else if index == last {
               // on the last of many
-              format!("{}", path)
+              path.to_string()
             } else {
               format!("{},", path)
             }

--- a/membrane/src/utils.rs
+++ b/membrane/src/utils.rs
@@ -1,3 +1,4 @@
+use crate::SourceCodeLocation;
 use allo_isolate::Isolate;
 use serde::ser::Serialize;
 
@@ -17,5 +18,67 @@ pub fn send<T: Serialize, E: Serialize>(isolate: Isolate, result: Result<T, E>) 
         false
       }
     }
+  }
+}
+
+pub(crate) fn display_code_location(location: Option<&Vec<SourceCodeLocation>>) -> String {
+  match location {
+    Some(loc) if !loc.is_empty() => {
+      let last = loc.len() - 1;
+      format!(
+        " at {}",
+        loc
+          .iter()
+          .enumerate()
+          .map(|(index, path)| {
+            if last == 0 {
+              // single item
+              format!("{}", path)
+            } else if index == 0 && last == 1 {
+              // on the first of two
+              format!("{} and", path)
+            } else if index == 1 && last == 1 {
+              // on the second of two
+              format!("{}", path)
+            } else if index == (last - 1) {
+              // on the next to last of many
+              format!("{}, and", path)
+            } else if index == last {
+              // on the last of many
+              format!("{}", path)
+            } else {
+              format!("{},", path)
+            }
+          })
+          .collect::<Vec<String>>()
+          .join(" ")
+      )
+    }
+    _ => String::new(),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::display_code_location;
+
+  #[test]
+  fn test_source_code_display_location() {
+    assert_eq!(display_code_location(Some(&vec![])), "");
+
+    assert_eq!(
+      display_code_location(Some(&vec!["app.rs:30"])),
+      " at app.rs:30"
+    );
+
+    assert_eq!(
+      display_code_location(Some(&vec!["app.rs:30", "foo.rs:10"])),
+      " at app.rs:30 and foo.rs:10"
+    );
+
+    assert_eq!(
+      display_code_location(Some(&vec!["app.rs:30", "foo.rs:10", "bar.rs:5"])),
+      " at app.rs:30, foo.rs:10, and bar.rs:5"
+    );
   }
 }

--- a/membrane/tests/codegen_self_borrow_test.rs
+++ b/membrane/tests/codegen_self_borrow_test.rs
@@ -36,7 +36,7 @@ mod test {
 
     assert_eq!(
       membrane.drain_errors(),
-      vec!["`a::Location` was borrowed by `a` which is a self reference"]
+      vec!["`a::Location` at membrane/tests/codegen_self_borrow_test.rs:19 was borrowed by `a` which is a self reference"]
     );
   }
 }

--- a/membrane_macro/src/lib.rs
+++ b/membrane_macro/src/lib.rs
@@ -345,6 +345,7 @@ fn to_token_stream(
     quote! { None }
   };
   let borrow = quote! { &[#(#borrow),*] };
+  let debug_location = quote! { concat!(file!(), ":", line!()) };
 
   let _deferred_trace = quote! {
       ::membrane::inventory::submit! {
@@ -365,6 +366,7 @@ fn to_token_stream(
                 dart_transforms: #dart_transforms,
                 dart_inner_args: #dart_inner_args,
                 output: "",
+                location: #debug_location,
               },
               namespace: #namespace,
               trace: |

--- a/membrane_macro/src/lib.rs
+++ b/membrane_macro/src/lib.rs
@@ -170,7 +170,7 @@ fn to_token_stream(
   let rust_outer_params: Vec<TokenStream2> = if sync {
     RustExternParams::try_from(&inputs)?.into()
   } else {
-    vec![
+    [
       vec![quote! {membrane_port: i64}],
       RustExternParams::try_from(&inputs)?.into(),
     ]


### PR DESCRIPTION
This PR:

* updates the borrow system to include which macro caused the error
* makes the logger in generated code configurable